### PR TITLE
fix: Support docusaurus sidebar position for ordering

### DIFF
--- a/src/content/md.ts
+++ b/src/content/md.ts
@@ -327,10 +327,7 @@ export class MarkdownTree {
 
     return {
       frontmatter: frontmatter.data,
-      weight:
-        frontmatter.data.weight !== undefined
-          ? Number(frontmatter.data.weight)
-          : 999,
+      weight: determineContentWeight(frontmatter.data),
     };
   }
 
@@ -776,6 +773,31 @@ export function getFlattenedTree(
 ) {
   const tree = new MarkdownTree(rootPath, defaultLanguage);
   return tree.getFlattenedTree();
+}
+
+/**
+ * Determines the weight of content based on frontmatter properties.
+ *
+ * Checks for weight-related properties in the frontmatter and returns
+ * a numeric weight for sorting purposes. Prioritizes "weight" over
+ * "sidebar_position" and defaults to 999 if neither is found.
+ *
+ * @param frontmatter - Parsed frontmatter data as key-value pairs
+ * @returns Numeric weight for sorting, lower values appear first
+ */
+function determineContentWeight(frontmatter: Record<string, unknown>): number {
+  // First check for explicit weight property
+  if (frontmatter.weight !== undefined) {
+    return Number(frontmatter.weight);
+  }
+
+  // Fall back to sidebar_position if weight is not specified
+  if (frontmatter.sidebar_position !== undefined) {
+    return Number(frontmatter.sidebar_position);
+  }
+
+  // Default weight if neither property is found
+  return 999;
 }
 
 /**

--- a/tests/content/md.test.ts
+++ b/tests/content/md.test.ts
@@ -150,6 +150,65 @@ describe("MarkdownTree", () => {
       expect(lowNode?.weight).toBe(100);
     });
 
+    test("should handle sidebar_position frontmatter correctly", () => {
+      const rootPath = "/test-root";
+      mock({
+        [rootPath]: {
+          "first.md": "---\nsidebar_position: 1\n---\n# First",
+          "third.md": "---\nsidebar_position: 3\n---\n# Third",
+          "second.md": "---\nsidebar_position: 2\n---\n# Second",
+        },
+      });
+
+      const tree = new MarkdownTree(rootPath);
+      const flattenedTree = tree.getFlattenedTree();
+
+      expect(flattenedTree.length).toBe(3);
+
+      const firstNode = flattenedTree[0];
+      const secondNode = flattenedTree[1];
+      const thirdNode = flattenedTree[2];
+
+      expect(firstNode).toBeDefined();
+      expect(firstNode?.weight).toBe(1);
+
+      expect(secondNode).toBeDefined();
+      expect(secondNode?.weight).toBe(2);
+
+      expect(thirdNode).toBeDefined();
+      expect(thirdNode?.weight).toBe(3);
+    });
+
+    test("should prioritize weight over sidebar_position", () => {
+      const rootPath = "/test-root";
+      mock({
+        [rootPath]: {
+          "explicit-weight.md":
+            "---\nweight: 5\nsidebar_position: 10\n---\n# Explicit Weight",
+          "sidebar-only.md": "---\nsidebar_position: 3\n---\n# Sidebar Only",
+          "no-weight.md": "# No Weight",
+        },
+      });
+
+      const tree = new MarkdownTree(rootPath);
+      const flattenedTree = tree.getFlattenedTree();
+
+      expect(flattenedTree.length).toBe(3);
+
+      const sidebarOnlyNode = flattenedTree[0];
+      const explicitWeightNode = flattenedTree[1];
+      const noWeightNode = flattenedTree[2];
+
+      expect(sidebarOnlyNode).toBeDefined();
+      expect(sidebarOnlyNode?.weight).toBe(3);
+
+      expect(explicitWeightNode).toBeDefined();
+      expect(explicitWeightNode?.weight).toBe(5); // weight takes precedence over sidebar_position
+
+      expect(noWeightNode).toBeDefined();
+      expect(noWeightNode?.weight).toBe(999); // default weight
+    });
+
     test("should handle index files correctly", () => {
       const rootPath = "/test-root";
       mock({


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adds support for `sidebar_position` in frontmatter for ordering as used by docusaurus instead of just `weight`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
