### PR TITLE
feat: Initial MCP server implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ CLI tools for maintaining Markdown content like documentation and tutorials.
 - **📝 Style Guide Enforcement** - Maintain consistency with custom style guides
 - **⚡ Rate Limiting** - Built-in rate limiting for API calls
 - **🎯 Context-Aware Processing** - Smart content processing with configurable context strategies
+- **🔌 Model Context Protocol Server** - Integrate with tools like Cursor, Cline and Q Developer with the built-in MCP server
 
 ## Installation
 
@@ -38,6 +39,12 @@ Write the changes directly back to the source files:
 
 ```bash
 toolkit-md review --write ./docs
+```
+
+Provide some additional instructions:
+
+```bash
+toolkit-md review --write ./docs --instructions 'Add more detailed explanations to the introduction page'
 ```
 
 ### Translate Content
@@ -66,22 +73,23 @@ Toolkit for Markdown supports configuration through:
 
 **Configuration Options:**
 
-| Config Path             | CLI Flag             | Environment Variable          | Description                                                                                  | Default                                       |
-| ----------------------- | -------------------- | ----------------------------- | -------------------------------------------------------------------------------------------- | --------------------------------------------- |
-| `baseDir`               | `--base-dir`         | `TKMD_BASE_DIR`               | Base directory for relative paths                                                            | `"."`                                         |
-| `language`              | `--language`         | `TKMD_LANGUAGE`               | Source language code                                                                         | `"en"`                                        |
-| `defaultLanguage`       | `--default-language` | `TKMD_DEFAULT_LANGUAGE`       | Language for files without explicit markers                                                  | `"en"`                                        |
-| `ai.model`              | `--model`            | `TKMD_AI_MODEL`               | Amazon Bedrock model ID                                                                      | `"anthropic.claude-3-5-sonnet-20241022-v2:0"` |
-| `ai.maxTokens`          | `--max-tokens`       | `TKMD_AI_MAX_TOKENS`          | Maximum output tokens                                                                        | `4096`                                        |
-| `ai.write`              | `--write`            | `TKMD_AI_WRITE`               | Write changes directly to files                                                              | `false`                                       |
-| `ai.rate.requests`      | `--request-rate`     | `TKMD_AI_REQUEST_RATE_LIMIT`  | Max requests per minute (0 = unlimited)                                                      | `0`                                           |
-| `ai.rate.tokens`        | `--token-rate`       | `TKMD_AI_TOKEN_RATE_LIMIT`    | Max tokens per minute (0 = unlimited)                                                        | `0`                                           |
-| `ai.contextStrategy`    | `--context-strategy` | `TKMD_AI_CONTEXT_STRATEGY`    | Context inclusion: "siblings", "nothing", "everything"                                       | `"nothing"`                                   |
-| `ai.exemplars`          | `--exemplar`         | `TKMD_AI_EXEMPLAR_*`          | Path to directory of content to use as an example to follow, can be specified multiple times | `[]`                                          |
-| `ai.styleGuides`        | `--style-guide`      | `TKMD_AI_STYLE_GUIDE_*`       | Path to style guide file, can be specified multiple times                                    | `[]`                                          |
-| `ai.review.summaryFile` | `--summary-file`     | `TKMD_AI_REVIEW_SUMMARY_PATH` | Write a summary of the review changes to the provided file path in Markdown format           | `""`                                          |
-| `ai.translation.force`  | `--force`            | `TKMD_AI_FORCE_TRANSLATION`   | Force translation even if source unchanged                                                   | `false`                                       |
-| `ai.translation.check`  | `--check`            | `TKMD_AI_CHECK_TRANSLATION`   | Only check if translation needed                                                             | `false`                                       |
+| Config Path              | CLI Flag             | Environment Variable          | Description                                                                                  | Default                                       |
+| ------------------------ | -------------------- | ----------------------------- | -------------------------------------------------------------------------------------------- | --------------------------------------------- |
+| `contentDir`             | `--content-dir`      | `TKMD_CONTENT_DIR`            | Directory relative to the cwd where content is hosted                                        | `undefined`                                   |
+| `language`               | `--language`         | `TKMD_LANGUAGE`               | Source language code                                                                         | `"en"`                                        |
+| `defaultLanguage`        | `--default-language` | `TKMD_DEFAULT_LANGUAGE`       | Language for files without explicit markers                                                  | `"en"`                                        |
+| `ai.model`               | `--model`            | `TKMD_AI_MODEL`               | Amazon Bedrock model ID                                                                      | `"anthropic.claude-3-5-sonnet-20241022-v2:0"` |
+| `ai.maxTokens`           | `--max-tokens`       | `TKMD_AI_MAX_TOKENS`          | Maximum output tokens                                                                        | `4096`                                        |
+| `ai.write`               | `--write`            | `TKMD_AI_WRITE`               | Write changes directly to files                                                              | `false`                                       |
+| `ai.rate.requests`       | `--request-rate`     | `TKMD_AI_REQUEST_RATE_LIMIT`  | Max requests per minute (0 = unlimited)                                                      | `0`                                           |
+| `ai.rate.tokens`         | `--token-rate`       | `TKMD_AI_TOKEN_RATE_LIMIT`    | Max tokens per minute (0 = unlimited)                                                        | `0`                                           |
+| `ai.contextStrategy`     | `--context-strategy` | `TKMD_AI_CONTEXT_STRATEGY`    | Context inclusion: "siblings", "nothing", "everything"                                       | `"nothing"`                                   |
+| `ai.exemplars`           | `--exemplar`         | `TKMD_AI_EXEMPLAR_*`          | Path to directory of content to use as an example to follow, can be specified multiple times | `[]`                                          |
+| `ai.styleGuides`         | `--style-guide`      | `TKMD_AI_STYLE_GUIDE_*`       | Path to style guide file, can be specified multiple times                                    | `[]`                                          |
+| `ai.review.instructions` | `--instructions`     | `TKMD_AI_REVIEW_INSTRUCTIONS` | Additional instructions for the model                                                        | `undefined`                                   |
+| `ai.review.summaryFile`  | `--summary-file`     | `TKMD_AI_REVIEW_SUMMARY_PATH` | Write a summary of the review changes to the provided file path in Markdown format           | `""`                                          |
+| `ai.translation.force`   | `--force`            | `TKMD_AI_FORCE_TRANSLATION`   | Force translation even if source unchanged                                                   | `false`                                       |
+| `ai.translation.check`   | `--check`            | `TKMD_AI_CHECK_TRANSLATION`   | Only check if translation needed                                                             | `false`                                       |
 
 **Note:** For array values (exemplars, styleGuides), the environment variable referenced above is treated as a prefix: `TKMD_AI_EXEMPLAR_FIRST`, `TKMD_AI_EXEMPLAR_SECOND`, etc.
 
@@ -112,6 +120,52 @@ Create a `.toolkit-mdrc` file in JSON format:
   }
 }
 ```
+
+### Changing the working directory
+
+Adding a `.toolkit-mdrc` file to a project is a useful way to set default configuration values for that project. The most effective way to make sure that the correct configuration file is picked up is to run `toolkit-md` from the directory of the project itself.
+
+An alternative approach is to use the `--cwd` flag to change what the tool considers the current directory:
+
+```bash
+toolkit-md review --cwd ~/projects/my-project ./docs
+```
+
+This will:
+
+1. Try to load a configuration file from `~/projects/my-project/.toolkit-mdrc`
+2. Review the content in `~/projects/my-project/docs`
+
+### Configuring a content directory
+
+Its not unusual for Markdown content to be stored in a sub-directory of an overall project.
+
+For example:
+
+```
+docs/.                      ← **Markdown documentation**
+├── guide/
+│   ├── getting-started.md
+│   ├── installation.md
+│   └── configuration.md
+└── api/
+    ├── authentication.md
+    └── endpoints.md
+src/                        ← **Other source code**
+```
+
+The `--content-dir` parameter can be used to information `toolkit-md` that a sub-directory is what it should consider the "root" for Markdown content.
+
+```bash
+toolkit-md review --content-dir ./docs ./guide
+```
+
+This will review the content in `./docs/guide`.
+
+Taking this approach has several benefits:
+
+1. It shortens the parameter used to target subsets of content for review
+2. It allows `toolkit-md` to generate more succinct, targeted directory and file structure listings that can be provided to LLMs. Instead of mapping the entire project repository, it can focus on the specific directory that contains Markdown. This saves tokens and reduces the context sent to the model.
 
 ### Style Guides
 
@@ -237,13 +291,14 @@ toolkit-md review ./docs --write --style-guide ./guides/style.md --context-strat
 - `--default-language`
 - `--model`
 - `--max-tokens`
-- `--base-dir`
+- `--content-dir`
 - `--request-rate`
 - `--token-rate`
 - `--context-strategy`
 - `--exemplar`
 - `--style-guide`
 - `--summary-file`
+- `--instructions`
 
 ### `translate`
 
@@ -263,7 +318,7 @@ toolkit-md translate ./docs --to fr --write --exemplar ./examples/french-docs
 - `--default-language`
 - `--model`
 - `--max-tokens`
-- `--base-dir`
+- `--content-dir`
 - `--request-rate`
 - `--token-rate`
 - `--context-strategy`
@@ -289,11 +344,58 @@ toolkit-md ask ./docs --question "What are the installation requirements and set
 - `--default-language`
 - `--model`
 - `--max-tokens`
-- `--base-dir`
+- `--content-dir`
 - `--request-rate`
 - `--token-rate`
 - `--exemplar`
 - `--style-guide`
+
+## Model Context Protocol server
+
+The built-in MCP server allows tools like Cursor, Cline and Q Developer to integrate and leverage the same Markdown file discovery, parsing and style guides as running the CLI commands. This is useful when working in an IDE to write new content or review existing content using agentic AI tools.
+
+Some example prompts:
+
+"Review the markdown content in this project for issues and best practices"
+
+"Translate the markdown content section on Amazon DynamoDB to French"
+
+Here is an example of configuring the MCP server in Q Developer:
+
+```json
+{
+  "mcpServers": {
+    "toolkit-md": {
+      "command": "toolkit-md",
+      "timeout": 10000,
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+Alternatively you can use `npx`:
+
+```json
+{
+  "mcpServers": {
+    "toolkit-md": {
+      "command": "npx",
+      "timeout": 10000,
+      "args": ["@aws/toolkit-md", "mcp"]
+    }
+  }
+}
+```
+
+For safety purposes the MCP server will refuse to load files from outside the current working directory that the MCP is running in. You can override the current working directory using the `--cwd` flag to broaden the files accessible.
+
+The following MCP tools are provided:
+
+| Tools                    | Description                                                                                                                                                                                                        |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `content_map`            | Response provides an ordered file/directory textual structured map of the Markdown content for the specified project. This can be useful for a model to efficiently navigate around large Markdown projects.       |
+| `content_best_practices` | Response contains style guide and exemplar content as configured for the specified project. It the `targetLanguage` is provided it will also load style guides for that language and provide them in the response. |
 
 ## Development
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "author": "",
   "dependencies": {
     "@aws-sdk/client-bedrock-runtime": "^3.785.0",
+    "@modelcontextprotocol/sdk": "^1.18.2",
     "chalk": "^5.3.0",
     "commander": "^14.0.0",
     "diff": "^7.0.0",
@@ -41,7 +42,7 @@
     "ora": "^8.0.1",
     "tiktoken": "^1.0.20",
     "yaml": "^2.8.0",
-    "zod": "^3.25.68"
+    "zod": "^3.25.75"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.0.6",

--- a/src/ai/prompts/bestPracticesPrompt.ts
+++ b/src/ai/prompts/bestPracticesPrompt.ts
@@ -15,30 +15,32 @@
  */
 
 import Handlebars from "handlebars";
-import type { TreeNode } from "../../content/index.js";
 import type { Language } from "../../languages/index.js";
-import { buildContextPrompt } from "./contextPrompt.js";
-import type { Exemplar, Prompt } from "./types.js";
+import { buildExemplarPrompt } from "./exemplarPrompt.js";
+import { buildStyleGuidePrompt } from "./styleGuidePrompt.js";
+import type { Exemplar } from "./types.js";
 
-const template = `Your task is the answer the following query related to the specified content:
+const template = `These are best practices for writing Markdown content for this project:
 
-{{{question}}}`;
+{{{styleGuidePrompt}}}
 
-export function buildAskPrompt(
-  question: string,
-  nodes: TreeNode[],
+{{{exemplarPrompt}}}
+`;
+
+export function buildBestPracticesPrompt(
   language: Language,
   styleGuides: string[],
-  exemplars: Exemplar[],
-): Prompt {
+  exemplarNodes: Exemplar[],
+) {
   const promptTemplate = Handlebars.compile(template);
 
-  const context = buildContextPrompt(nodes, language, styleGuides, exemplars);
+  const styleGuidePrompt = buildStyleGuidePrompt(styleGuides);
 
-  return {
-    context,
-    prompt: promptTemplate({
-      question,
-    }),
-  };
+  const exemplarPrompt = buildExemplarPrompt(language, exemplarNodes);
+
+  return promptTemplate({
+    styleGuidePrompt,
+    exemplarPrompt,
+    language: language.name,
+  }).trim();
 }

--- a/src/ai/prompts/contentMapPrompt.ts
+++ b/src/ai/prompts/contentMapPrompt.ts
@@ -15,30 +15,28 @@
  */
 
 import Handlebars from "handlebars";
-import type { TreeNode } from "../../content/index.js";
+import type { MarkdownTree } from "../../content/md.js";
 import type { Language } from "../../languages/index.js";
-import { buildContextPrompt } from "./contextPrompt.js";
-import type { Exemplar, Prompt } from "./types.js";
 
-const template = `Your task is the answer the following query related to the specified content:
+const template = `This is a map of Markdown content in this project in {{language.name}}. All files are relative to the following directory:
 
-{{{question}}}`;
+{{{rootDir}}}
 
-export function buildAskPrompt(
-  question: string,
-  nodes: TreeNode[],
-  language: Language,
-  styleGuides: string[],
-  exemplars: Exemplar[],
-): Prompt {
+Content map is as follows:
+
+{{#if contentMap.length}}
+{{{contentMap}}}
+{{else}}
+No content was found
+{{/if}}
+`;
+
+export function buildContentMapPrompt(tree: MarkdownTree, language: Language) {
   const promptTemplate = Handlebars.compile(template);
 
-  const context = buildContextPrompt(nodes, language, styleGuides, exemplars);
-
-  return {
-    context,
-    prompt: promptTemplate({
-      question,
-    }),
-  };
+  return promptTemplate({
+    rootDir: tree.getTree().path,
+    contentMap: tree.getTreeMap(language.code),
+    language,
+  }).trim();
 }

--- a/src/ai/prompts/contentSummaryPrompt.ts
+++ b/src/ai/prompts/contentSummaryPrompt.ts
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2025 Amazon.com, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Handlebars from "handlebars";
+import type { MarkdownTree } from "../../content/index.js";
+import type { Language } from "../../languages/index.js";
+import { buildContentMapPrompt } from "./contentMapPrompt.js";
+
+const template = `The following is a summary of the Markdown content in the project in directory "{{projectDirectory}}".
+
+{{#if contentDirectory}}
+Markdown content in this project is located in the content directory "{{contentDirectory}}".
+{{else}}
+The project directory is considered the content directory for this project.
+{{/if}}
+
+The default language is {{language.name}} ({{language.code}}) and if no language is explicity specified this will be used for all other operations.
+
+When discovering Markdown files in the repository if no language is found in the file name then it will be assumed to be {{language.name}} ({{language.code}}).
+
+For example, a file "test.md" is assumed to be {{defaultLanguage.name}} even if its not named "test.{{defaultLanguage.code}}.md".
+
+## Content map
+
+{{{contentMap}}}
+`;
+
+export function buildContentSummaryPrompt(
+  tree: MarkdownTree,
+  projectDirectory: string,
+  contentDirectory: string | undefined,
+  language: Language,
+  defaultLanguage: Language,
+  sourceLanguage: Language,
+): string {
+  const promptTemplate = Handlebars.compile(template);
+
+  const contentMap = buildContentMapPrompt(tree, sourceLanguage);
+
+  return promptTemplate({
+    language,
+    projectDirectory,
+    contentDirectory,
+    defaultLanguage,
+    sourceLanguage,
+    contentMap,
+  });
+}

--- a/src/ai/prompts/exemplarPrompt.ts
+++ b/src/ai/prompts/exemplarPrompt.ts
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2025 Amazon.com, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Handlebars from "handlebars";
+import type { Language } from "../../languages/index.js";
+import type { Exemplar } from "./types.js";
+import { buildFileList } from "./utils.js";
+
+const template = `{{#if exemplarFiles.length}}
+# Exemplar content
+
+The following content has been provided as a reference of what good content looks like and recommendations should follow their style.
+
+There are one or more examples, each contained within <example></example> tags.
+
+Each example may have one or more files across which the content is split, contained within <example_file></example_file> tags.
+
+{{#each exemplarFiles}}
+<example path="{{this.path}}">
+{{#each this.files}}
+<example_file path="{{this.path}}">
+{{{this.content}}}
+</example_file>
+{{/each}}
+<example>
+{{/each}}
+{{/if}}`;
+
+export function buildExemplarPrompt(language: Language, exemplars: Exemplar[]) {
+  const promptTemplate = Handlebars.compile(template);
+
+  const exemplarFiles: ExemplarFiles[] = [];
+
+  for (const exemplar of exemplars) {
+    exemplarFiles.push({
+      path: exemplar.path,
+      files: buildFileList(exemplar.nodes, language),
+    });
+  }
+
+  return promptTemplate({
+    exemplarFiles,
+  }).trim();
+}
+
+interface ExemplarFiles {
+  path: string;
+  files: File[];
+}
+
+interface File {
+  path: string;
+  content: string;
+}

--- a/src/ai/prompts/index.ts
+++ b/src/ai/prompts/index.ts
@@ -15,9 +15,13 @@
  */
 
 export * from "./askPrompt.js";
+export * from "./contentMapPrompt.js";
+export * from "./contentSummaryPrompt.js";
 export * from "./contextPrompt.js";
+export * from "./reviewAgentPrompt.js";
 export * from "./reviewPrompt.js";
 export * from "./summaryPrompt.js";
+export * from "./translationAgentPrompt.js";
 export * from "./translatePrompt.js";
 
 export * from "./types.js";

--- a/src/ai/prompts/reviewAgentPrompt.ts
+++ b/src/ai/prompts/reviewAgentPrompt.ts
@@ -1,0 +1,81 @@
+/**
+ * Copyright 2025 Amazon.com, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Handlebars from "handlebars";
+import type { MarkdownTree } from "../../content/index.js";
+import type { Language } from "../../languages/index.js";
+import { buildContentMapPrompt } from "./contentMapPrompt.js";
+import { buildStyleGuidePrompt } from "./styleGuidePrompt.js";
+import type { Prompt } from "./types.js";
+
+const template = `The following are instructions to review Markdown content as requested".
+
+1. Break the overall review task down in to sub-tasks, for example reviewing a directory at a time.
+2. Only review the files that map to the requested content. This could be the entire set of content or a sub-set.
+3. Read the Markdown files for the requested content to be reviewed in the source language.
+5. Review the content for issues as outlined below.
+6. Update the original files with the suggest changes.
+
+Your task is to review the requested files to improve them in terms of:
+- Spelling, grammar, syntax and other language issues or errors
+- Clarity and conciseness
+- Accurancy and thoroughness of explanations or context
+- Consistency with any style guides or exemplar content that has been provided
+
+If no improvements are identified for a given file then do not update it.
+
+{{#if instructions}}
+In additional you've been provided the following additional instructions:
+{{{instructions}}}
+{{/if}}
+
+{{#if includeContentMap}}
+## Content map
+
+{{#if contentMap.length}}
+{{{contentMap}}}
+{{else}}
+No Markdown content was found based on the provided criteria.
+{{/if}}
+{{/if}}
+
+{{#if styleGuidePrompt.length}}
+## Style best practices
+
+{{{styleGuidePrompt}}}
+{{/if}}
+`;
+
+export function buildReviewAgentPrompt(
+  tree: MarkdownTree,
+  language: Language,
+  includeContentMap: boolean,
+  styleGuides: string[],
+): Prompt {
+  const promptTemplate = Handlebars.compile(template);
+
+  const contentMap = buildContentMapPrompt(tree, language);
+
+  const styleGuidePrompt = buildStyleGuidePrompt(styleGuides);
+
+  return {
+    prompt: promptTemplate({
+      includeContentMap,
+      contentMap,
+      styleGuidePrompt,
+    }),
+  };
+}

--- a/src/ai/prompts/styleGuidePrompt.ts
+++ b/src/ai/prompts/styleGuidePrompt.ts
@@ -14,9 +14,23 @@
  * limitations under the License.
  */
 
-export * from "./ask.js";
-export * from "./mcp.js";
-export * from "./review.js";
-export * from "./translate.js";
+import Handlebars from "handlebars";
 
-export * from "./utils.js";
+const template = `{{#if styleGuides.length}}
+The follow are style guidelines that the content should follow contained between <style></style> tags:
+{{#each styleGuides}}
+<style>
+{{{this}}}
+</style>
+{{/each}}
+{{/if}}`;
+
+export function buildStyleGuidePrompt(styleGuides: string[]) {
+  if (styleGuides.length === 0) return "";
+
+  const promptTemplate = Handlebars.compile(template);
+
+  return promptTemplate({
+    styleGuides,
+  }).trim();
+}

--- a/src/ai/prompts/translatePrompt.ts
+++ b/src/ai/prompts/translatePrompt.ts
@@ -23,7 +23,7 @@ import {
 } from "../../content/index.js";
 import type { Language } from "../../languages/index.js";
 import { buildContextPrompt } from "./contextPrompt.js";
-import type { Prompt } from "./types.js";
+import type { Exemplar, Prompt } from "./types.js";
 import {
   type ContextStrategy,
   extractFileSection,
@@ -36,7 +36,9 @@ DO NOT make any changes not related to translating the content
 ALWAYS return the entire translated file, do not abbreviate it
 ALWAYS add or update the Markdown frontmatter with a key '${TRANSLATION_SRC_HASH_KEY}' with value '{{sourceHash}}'
 
-Write the output as markdown in a similar style to the example content. Respond with the resulting file enclosed in <file></file> including the path to the file as an attribute
+Write the output as markdown in a similar style to the example content. Respond with the resulting file enclosed in "<file></file>" tags including the path to the file as an attribute
+
+ONLY respond with the content between the "<file></file>" tags.
 
 {{#if existingTranslation}}
 The existing translation for this file is provided below enclosed in <existingTranslation></existingTranslation>. Use this as a reference and update it an necessary based on the provided source file.
@@ -56,7 +58,7 @@ export function buildTranslatePrompt(
   targetLanguage: Language,
   contextStrategy: ContextStrategy,
   styleGuides: string[],
-  exemplarNodes: TreeNode[],
+  exemplars: Exemplar[],
 ): Prompt {
   const promptTemplate = Handlebars.compile(template);
 
@@ -66,7 +68,7 @@ export function buildTranslatePrompt(
     contextNodes,
     sourceLanguage,
     styleGuides,
-    exemplarNodes,
+    exemplars,
   );
 
   return {

--- a/src/ai/prompts/translationAgentPrompt.ts
+++ b/src/ai/prompts/translationAgentPrompt.ts
@@ -1,0 +1,88 @@
+/**
+ * Copyright 2025 Amazon.com, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Handlebars from "handlebars";
+import type { MarkdownTree } from "../../content/index.js";
+import type { Language } from "../../languages/index.js";
+import { buildContentMapPrompt } from "./contentMapPrompt.js";
+import { buildStyleGuidePrompt } from "./styleGuidePrompt.js";
+import type { Prompt } from "./types.js";
+
+const template = `The following are instructions to translate Markdown content from "{{sourceLanguage.name}}" to "{{targetLanguage.name}}".
+
+1. Break the overall translation task down in to sub-tasks, for example translating a directory at a time.
+2. Only translate the files that map to the requested content. This could be the entire set of content or a sub-set.
+3. Read the Markdown files for the requested content to be translated in the source language.
+4. Check for an existing translation in the requested language. If it exists, use it as a starting point for the translation.
+5. Translate the source content to the requested language.
+6. Write the translated content for each file in the requested language in the same format as the source language.
+
+ONLY make changes to the content related to translation.
+
+The file naming for the translated content is of the following format:
+
+<file name>.<language short code>.md
+
+For example a file "test.{{sourceLanguage.code}}.md" or "test.md" translated to {{targetLanguage.name}} would be written to "test.{{targetLanguage.code}}.md".
+
+{{#if includeSourceContentMap}}
+## Source language content map
+
+{{#if sourceContentMap.length}}
+{{{sourceContentMap}}}
+{{else}}
+No source Markdown content was found based on the provided criteria.
+{{/if}}
+{{/if}}
+
+## Target language content map
+
+{{#if targetContentMap.length}}
+{{{targetContentMap}}}
+{{else}}
+No existing translated Markdown content was found based on the provided criteria.
+{{/if}}
+
+## Style best practices
+
+{{{styleGuidePrompt}}}
+`;
+
+export function buildTranslationAgentPrompt(
+  tree: MarkdownTree,
+  sourceLanguage: Language,
+  targetLanguage: Language,
+  includeSourceContentMap: boolean,
+  styleGuides: string[],
+): Prompt {
+  const promptTemplate = Handlebars.compile(template);
+
+  const sourceContentMap = buildContentMapPrompt(tree, sourceLanguage);
+  const targetContentMap = buildContentMapPrompt(tree, targetLanguage);
+
+  const styleGuidePrompt = buildStyleGuidePrompt(styleGuides);
+
+  return {
+    prompt: promptTemplate({
+      includeSourceContentMap,
+      sourceContentMap,
+      targetContentMap,
+      sourceLanguage,
+      targetLanguage,
+      styleGuidePrompt,
+    }),
+  };
+}

--- a/src/ai/prompts/types.ts
+++ b/src/ai/prompts/types.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import type { TreeNode } from "../../content/index.js";
+
 /**
  * Represents a prompt configuration for AI model interactions.
  * This interface defines the structure of prompts sent to language models.
@@ -52,4 +54,10 @@ export interface Prompt {
    * @returns The transformed response string
    */
   transform?: (input: string) => string;
+}
+
+export interface Exemplar {
+  path: string;
+
+  nodes: TreeNode[];
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,16 +18,14 @@
 import { Command } from "commander";
 import {
   createAskCommand,
+  createMcpCommand,
   createReviewCommand,
   createTranslateCommand,
 } from "./commands/index.js";
-import { logoText, rainbowText } from "./utils.js";
 
 // x-release-please-start-version
 export const VERSION = "0.1.4";
 // x-release-please-end
-
-console.log(rainbowText(logoText));
 
 process.on("SIGINT", () => {
   console.log("\nGracefully shutting down from SIGINT (Ctrl-C)");
@@ -40,6 +38,7 @@ program
   .version(VERSION)
   .addCommand(createReviewCommand())
   .addCommand(createTranslateCommand())
-  .addCommand(createAskCommand());
+  .addCommand(createAskCommand())
+  .addCommand(createMcpCommand());
 
 await program.parse();

--- a/src/commands/logger.ts
+++ b/src/commands/logger.ts
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2025 Amazon.com, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface LogWriter {
+  message(message: string): void;
+
+  error(message: string): void;
+}
+
+export class ConsoleLogger implements LogWriter {
+  message(message: string): void {
+    console.log(message);
+  }
+
+  error(message: string): void {
+    console.error(message);
+  }
+}
+
+export class ConsoleErrorLogger implements LogWriter {
+  message(message: string): void {
+    console.error(message);
+  }
+
+  error(message: string): void {
+    console.error(message);
+  }
+}
+
+export class NoopLogger implements LogWriter {
+  message(_message: string): void {
+    // Do nothing
+  }
+
+  error(_message: string): void {
+    // Do nothing
+  }
+}

--- a/src/commands/logo.ts
+++ b/src/commands/logo.ts
@@ -1,0 +1,154 @@
+/**
+ * Copyright 2025 Amazon.com, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import chalk from "chalk";
+
+export const logoText = `
+
+████████╗ ██████╗  ██████╗ ██╗     ██╗  ██╗██╗████████╗    ███╗   ███╗██████╗ 
+╚══██╔══╝██╔═══██╗██╔═══██╗██║     ██║ ██╔╝██║╚══██╔══╝    ████╗ ████║██╔══██╗
+   ██║   ██║   ██║██║   ██║██║     █████╔╝ ██║   ██║       ██╔████╔██║██║  ██║
+   ██║   ██║   ██║██║   ██║██║     ██╔═██╗ ██║   ██║       ██║╚██╔╝██║██║  ██║
+   ██║   ╚██████╔╝╚██████╔╝███████╗██║  ██╗██║   ██║       ██║ ╚═╝ ██║██████╔╝
+   ╚═╝    ╚═════╝  ╚═════╝ ╚══════╝╚═╝  ╚═╝╚═╝   ╚═╝       ╚═╝     ╚═╝╚═════╝ 
+                                    
+
+`;
+
+export function logo() {
+  console.log(rainbowText(logoText));
+}
+
+/**
+ * Renders text with a blue gradient effect that spans across the entire text
+ *
+ * @param text - The input string to be colorized
+ * @param options - Optional configuration for the gradient effect
+ * @param options.startColor - Starting color of the gradient (default: dark blue)
+ * @param options.endColor - Ending color of the gradient (default: light blue)
+ * @param options.saturation - Color saturation percentage (0-100, default: 70)
+ * @returns The input text with blue gradient effect applied
+ *
+ * @example
+ * ```typescript
+ * console.log(rainbowText("Hello, World!"));
+ * console.log(rainbowText("Custom gradient!", {
+ *   startColor: { hue: 220, lightness: 20 },
+ *   endColor: { hue: 195, lightness: 70 }
+ * }));
+ * ```
+ */
+export function rainbowText(
+  text: string,
+  options: {
+    startColor?: { hue?: number; lightness?: number };
+    endColor?: { hue?: number; lightness?: number };
+    saturation?: number;
+  } = {},
+): string {
+  // Default to a dark blue to light blue gradient
+  const startHue = options.startColor?.hue ?? 230;
+  const startLightness = options.startColor?.lightness ?? 25;
+  const endHue = options.endColor?.hue ?? 210;
+  const endLightness = options.endColor?.lightness ?? 70;
+  const saturation = options.saturation ?? 70;
+
+  // Count visible characters (excluding newlines)
+  const visibleChars = text.replace(/\n/g, "").length;
+  if (visibleChars === 0) return "";
+
+  let result = "";
+  let visibleIndex = 0;
+
+  for (let i = 0; i < text.length; i++) {
+    if (text[i] === "\n") {
+      // Don't colorize newlines
+      result += text[i];
+    } else {
+      // Calculate the progress through the visible characters (0 to 1)
+      const progress = visibleChars > 1 ? visibleIndex / (visibleChars - 1) : 0;
+
+      // Interpolate between start and end colors
+      const hue = Math.floor(startHue + progress * (endHue - startHue));
+      const lightness = Math.floor(
+        startLightness + progress * (endLightness - startLightness),
+      );
+
+      // Apply the color to the current character
+      result += chalk.hex(hslToHex(hue, saturation, lightness))(text[i]);
+
+      visibleIndex++;
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Converts HSL color values to hexadecimal color code
+ *
+ * @param h - Hue (0-360)
+ * @param s - Saturation (0-100)
+ * @param l - Lightness (0-100)
+ * @returns Hexadecimal color code
+ * @private
+ */
+function hslToHex(h: number, s: number, l: number): string {
+  s /= 100;
+  l /= 100;
+
+  const c = (1 - Math.abs(2 * l - 1)) * s;
+  const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
+  const m = l - c / 2;
+
+  let r = 0,
+    g = 0,
+    b = 0;
+
+  if (0 <= h && h < 60) {
+    r = c;
+    g = x;
+    b = 0;
+  } else if (60 <= h && h < 120) {
+    r = x;
+    g = c;
+    b = 0;
+  } else if (120 <= h && h < 180) {
+    r = 0;
+    g = c;
+    b = x;
+  } else if (180 <= h && h < 240) {
+    r = 0;
+    g = x;
+    b = c;
+  } else if (240 <= h && h < 300) {
+    r = x;
+    g = 0;
+    b = c;
+  } else if (300 <= h && h < 360) {
+    r = c;
+    g = 0;
+    b = x;
+  }
+
+  // Convert to hex
+  const toHex = (value: number) => {
+    const hex = Math.round((value + m) * 255).toString(16);
+    return hex.length === 1 ? ("0" as const) + hex : hex;
+  };
+
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+}

--- a/src/commands/mcp.ts
+++ b/src/commands/mcp.ts
@@ -1,0 +1,395 @@
+/**
+ * Copyright 2025 Amazon.com, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import path from "node:path";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { Command } from "commander";
+import z from "zod";
+import { buildBestPracticesPrompt } from "../ai/prompts/bestPracticesPrompt.js";
+import {
+  buildContentSummaryPrompt,
+  buildReviewAgentPrompt,
+  buildTranslationAgentPrompt,
+} from "../ai/prompts/index.js";
+import { VERSION } from "../cli.js";
+import { ConfigManager } from "../config/index.js";
+import { MarkdownTree } from "../content/index.js";
+import { Language } from "../languages/index.js";
+import { ConsoleErrorLogger, NoopLogger } from "./logger.js";
+import { commonOptions, languageOptions } from "./options.js";
+import * as utils from "./utils.js";
+
+export function createMcpCommand(): Command {
+  const command = new Command("mcp");
+
+  commonOptions(command);
+  languageOptions(command);
+
+  command.description("Runs an MCP server").action(executeAction);
+
+  return command;
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: Need a better way to handle CLI options
+async function executeAction(options: any): Promise<void> {
+  const logger = new ConsoleErrorLogger();
+
+  logger.message("Starting MCP server...");
+
+  const server = new McpServer({
+    name: "toolkit-md-server",
+    version: VERSION,
+  });
+
+  const noopLogger = new NoopLogger();
+
+  const languages = [...Language.getLanguages().map((e) => e.code)].join(", ");
+
+  const cwd = utils.getCwd(options);
+
+  logger.message(`Working directory is: ${cwd}`);
+
+  server.registerTool(
+    "content_best_practices",
+    {
+      title: "Markdown Content Best Practices",
+      description:
+        "Provides style guides and best practice examples for creating and reviewing Markdown content for the specified project",
+      inputSchema: {
+        projectDirectory: z
+          .string()
+          .describe("Absolute path to base/root directory of the project"),
+        targetLanguage: z
+          .string()
+          .describe(
+            `Target language if translating the content, omit this if not intending to translate. Can be one of: ${languages}`,
+          )
+          .optional(),
+      },
+    },
+    async ({ projectDirectory, targetLanguage }) => {
+      utils.validatePathWithinCwd(projectDirectory, cwd);
+      const config = new ConfigManager(projectDirectory);
+      await config.initialize(options);
+
+      const projectDir = path.resolve(projectDirectory);
+
+      const { language, defaultLanguage } = utils.getLanguages(config);
+
+      const languages = [language];
+
+      if (targetLanguage) {
+        const resolvedTargetLanguage = Language.getLanguage(targetLanguage);
+
+        if (!resolvedTargetLanguage) {
+          throw new Error(`Invalid target language: ${targetLanguage}`);
+        }
+
+        languages.push(resolvedTargetLanguage);
+      }
+
+      const exemplars = utils.getExemplars(projectDir, defaultLanguage, config);
+
+      const styleGuides = utils.getStyleGuides(
+        projectDir,
+        config,
+        defaultLanguage,
+        noopLogger,
+        languages,
+      );
+
+      const prompt = buildBestPracticesPrompt(language, styleGuides, exemplars);
+
+      return { content: [{ type: "text", text: prompt }] };
+    },
+  );
+
+  server.registerTool(
+    "content_summary_information",
+    {
+      title: "Markdown Content Summary Information",
+      description: `Provides an overview of various information related to Markdown content in the specified project.
+      
+This information maybe useful by itself, but is often required by other tools. 
+
+For example some of the information it returns is:
+
+- The content directory path, which is a sub-directory under the project directory where Markdown is located
+- The default language configuration of the project
+- A content map of the Markdown files in a project which can be used to get an overview of the content in the project
+      
+The content map provides an ordered file/directory structure map of the Markdown content for the specified project.
+File paths are relative to the specified project directory.
+The title of the Markdown files are parsed from frontmatter if present.
+Use this tool to get a summary of the Markdown content in a project or locate files related to a specific topic.`,
+      inputSchema: {
+        projectDirectory: z
+          .string()
+          .describe("Absolute path to base/root directory of the project"),
+        language: z
+          .string()
+          .describe(
+            `Language for which to generate the content map. If omitted then the projects default language will be used. Can be one of: ${languages}`,
+          )
+          .optional(),
+      },
+    },
+    async ({ projectDirectory, language: sourceLanguage }) => {
+      utils.validatePathWithinCwd(projectDirectory, cwd);
+
+      const config = new ConfigManager(projectDirectory);
+      await config.initialize(options);
+
+      const projectDir = path.resolve(projectDirectory);
+
+      const contentDir = utils.getContentDir(config);
+
+      if (contentDir) {
+        utils.validatePathWithinCwd(contentDir, cwd);
+      }
+
+      const { language, defaultLanguage } = utils.getLanguages(config);
+
+      var resolvedSourceLanguage: Language | undefined = language;
+
+      if (sourceLanguage) {
+        resolvedSourceLanguage = Language.getLanguage(sourceLanguage);
+      } else {
+        resolvedSourceLanguage = language;
+      }
+
+      if (!resolvedSourceLanguage) {
+        throw new Error(`Invalid source language: ${sourceLanguage}`);
+      }
+
+      const tree = new MarkdownTree(
+        contentDir ?? projectDir,
+        defaultLanguage.code,
+        projectDirectory,
+      );
+
+      const prompt = buildContentSummaryPrompt(
+        tree,
+        projectDirectory,
+        contentDir,
+        language,
+        defaultLanguage,
+        resolvedSourceLanguage,
+      );
+
+      return { content: [{ type: "text", text: prompt }] };
+    },
+  );
+
+  server.registerTool(
+    "content_review_guidance",
+    {
+      title: "Markdown Content Review Guidance",
+      description:
+        "Provides guidance and instructions for reviewing Markdown content for the specified project for various issues and best practices. The response will include a content map of the project.",
+      inputSchema: {
+        projectDirectory: z
+          .string()
+          .describe("Absolute path to base/root directory of the project"),
+        sourceDirectory: z
+          .string()
+          .describe(
+            "Optional relative path to a sub-directory under the project content directory as specified by the content map. Use this to review a specific sub-directory, otherwise guidance will apply to all content in the project.",
+          )
+          .optional(),
+        language: z
+          .string()
+          .describe(
+            `Source language for reviewing the content. If omitted then the projects default language will be used. Can be one of: ${languages}`,
+          )
+          .optional(),
+        includeContentMap: z
+          .boolean()
+          .describe(
+            `Whether to include a content map of the Markdown files. This is not necessary if a content map has already been retrieved.`,
+          )
+          .default(false),
+      },
+    },
+    async ({
+      projectDirectory,
+      language: sourceLanguage,
+      includeContentMap,
+      sourceDirectory,
+    }) => {
+      utils.validatePathWithinCwd(projectDirectory, cwd);
+      const config = new ConfigManager(projectDirectory);
+      await config.initialize(options);
+
+      const projectDir = path.resolve(projectDirectory);
+
+      const contentDir = utils.getContentDir(config) || projectDir;
+
+      let resolvedSourceDirectory: string | undefined;
+
+      if (sourceDirectory) {
+        resolvedSourceDirectory = path.join(contentDir, sourceDirectory);
+      }
+
+      const { language, defaultLanguage } = utils.getLanguages(config);
+
+      const tree = new MarkdownTree(
+        resolvedSourceDirectory ?? contentDir,
+        defaultLanguage.code,
+        projectDirectory,
+      );
+
+      var resolvedSourceLanguage: Language | undefined;
+
+      if (sourceLanguage) {
+        resolvedSourceLanguage = Language.getLanguage(sourceLanguage);
+      } else {
+        resolvedSourceLanguage = language;
+      }
+
+      if (!resolvedSourceLanguage) {
+        throw new Error(`Invalid source language: ${sourceLanguage}`);
+      }
+
+      const styleGuides = utils.getStyleGuides(
+        projectDir,
+        config,
+        defaultLanguage,
+        noopLogger,
+        [language, resolvedSourceLanguage],
+      );
+
+      const prompt = buildReviewAgentPrompt(
+        tree,
+        resolvedSourceLanguage,
+        includeContentMap,
+        styleGuides,
+      );
+
+      return { content: [{ type: "text", text: prompt.prompt }] };
+    },
+  );
+
+  server.registerTool(
+    "content_translation_guidance",
+    {
+      title: "Markdown Content Translation Guidance",
+      description:
+        "Provides guidance and instructions for translating Markdown content for the specified project from one language to another. The response will include a content map of the target language.",
+      inputSchema: {
+        projectDirectory: z
+          .string()
+          .describe("Absolute path to base/root directory of the project"),
+        sourceDirectory: z
+          .string()
+          .describe(
+            "Optional relative path to a sub-directory under the project content directory as specified by the content map. Use this to translate a specific sub-directory, otherwise guidance will apply to all content in the project.",
+          )
+          .optional(),
+        language: z
+          .string()
+          .describe(
+            `Source language for translating the content. If omitted then the projects default language will be used. Can be one of: ${languages}`,
+          )
+          .optional(),
+        targetLanguage: z
+          .string()
+          .describe(
+            `Target language if translating the content, can be one of: ${languages}`,
+          ),
+        includeSourceContentMap: z
+          .boolean()
+          .describe(
+            `Whether to include a content map of the source language files. This is not necessary if a content map has already been retrieved.`,
+          )
+          .default(false),
+      },
+    },
+    async ({
+      projectDirectory,
+      language: sourceLanguage,
+      targetLanguage,
+      includeSourceContentMap,
+      sourceDirectory,
+    }) => {
+      utils.validatePathWithinCwd(projectDirectory, cwd);
+      const config = new ConfigManager(projectDirectory);
+      await config.initialize(options);
+
+      const projectDir = path.resolve(projectDirectory);
+
+      const contentDir = utils.getContentDir(config) || projectDir;
+
+      let resolvedSourceDirectory: string | undefined;
+
+      if (sourceDirectory) {
+        resolvedSourceDirectory = path.join(contentDir, sourceDirectory);
+      }
+
+      const { language, defaultLanguage } = utils.getLanguages(config);
+
+      const tree = new MarkdownTree(
+        resolvedSourceDirectory ?? contentDir,
+        defaultLanguage.code,
+        projectDirectory,
+      );
+
+      var resolvedSourceLanguage: Language | undefined;
+
+      if (sourceLanguage) {
+        resolvedSourceLanguage = Language.getLanguage(sourceLanguage);
+      } else {
+        resolvedSourceLanguage = language;
+      }
+
+      if (!resolvedSourceLanguage) {
+        throw new Error(`Invalid source language: ${sourceLanguage}`);
+      }
+
+      var resolvedTargetLanguage: Language | undefined;
+
+      if (targetLanguage) {
+        resolvedTargetLanguage = Language.getLanguage(targetLanguage);
+      }
+
+      if (!resolvedTargetLanguage) {
+        throw new Error(`Invalid target language: ${targetLanguage}`);
+      }
+
+      const styleGuides = utils.getStyleGuides(
+        projectDir,
+        config,
+        defaultLanguage,
+        noopLogger,
+        [language, resolvedTargetLanguage],
+      );
+
+      const prompt = buildTranslationAgentPrompt(
+        tree,
+        language,
+        resolvedTargetLanguage,
+        includeSourceContentMap,
+        styleGuides,
+      );
+
+      return { content: [{ type: "text", text: prompt.prompt }] };
+    },
+  );
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}

--- a/src/commands/options.ts
+++ b/src/commands/options.ts
@@ -16,7 +16,7 @@
 
 import type { Command } from "commander";
 import {
-  CONFIG_BASE_DIR,
+  CONFIG_CONTENT_DIR,
   CONFIG_CONTEXT_STRATEGY,
   CONFIG_DEFAULT_LANGUAGE,
   CONFIG_EXEMPLARS,
@@ -34,9 +34,18 @@ export const DEFAULT_MODEL = "anthropic.claude-3-5-sonnet-20241022-v2:0";
 export const DEFAULT_MAX_TOKENS = "4096";
 
 export function commonOptions(command: Command) {
-  utils.optionForConfigSchema(command, CONFIG_BASE_DIR);
+  command.option(
+    "--cwd <value>",
+    "Specify the current working directory for all commands",
+  );
+}
+
+export function commonAiOptions(command: Command) {
+  utils.optionForConfigSchema(command, CONFIG_CONTENT_DIR);
   utils.optionForConfigSchema(command, CONFIG_MODEL);
   utils.optionForConfigSchema(command, CONFIG_MAX_TOKENS);
+
+  commonOptions(command);
 }
 
 export function fileWriteOptions(command: Command) {

--- a/src/commands/utils.ts
+++ b/src/commands/utils.ts
@@ -21,15 +21,12 @@ import { type Command, Option } from "commander";
 import { diffWordsWithSpace } from "diff";
 import ora from "ora";
 import type z from "zod";
-import { ZodArray, ZodBoolean } from "zod";
-import type { ContextStrategy, TokenUsage } from "../ai/index.js";
+import { ZodArray, ZodBoolean, ZodDefault } from "zod";
+import type { ContextStrategy, Exemplar, TokenUsage } from "../ai/index.js";
 import type { ConfigManager } from "../config/index.js";
-import {
-  getFlattenedTree,
-  MarkdownTree,
-  type TreeNode,
-} from "../content/index.js";
+import { MarkdownTree } from "../content/index.js";
 import { Language } from "../languages/index.js";
+import { ConsoleLogger, type LogWriter } from "./logger.js";
 
 export function collect(value: unknown, previous: unknown[]) {
   return (previous ?? []).concat([value]);
@@ -63,8 +60,29 @@ export function buildPath<T extends string | undefined>(
   return filepath;
 }
 
-export function getBaseDir(config: ConfigManager) {
-  return path.resolve(config.get<string>("baseDir"));
+export function getContentDir(config: ConfigManager) {
+  const contentDir = config.get<string>("contentDir");
+
+  if (!contentDir) {
+    return undefined;
+  }
+
+  return path.resolve(path.join(config.getCwd(), contentDir));
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: Options not typed
+export function getCwd(options: any) {
+  return options.cwd ? path.resolve(options.cwd) : process.cwd();
+}
+
+export function validatePathWithinCwd(targetPath: string, cwd: string): void {
+  const resolvedTarget = path.resolve(targetPath);
+  const resolvedCwd = path.resolve(cwd);
+  const relative = path.relative(resolvedCwd, resolvedTarget);
+  
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new Error(`Access denied: path '${targetPath}' is outside the working directory`);
+  }
 }
 
 export function printRelativePath(filepath: string, baseDir: string) {
@@ -110,10 +128,10 @@ export function getLanguages(config: ConfigManager): {
   return { language, defaultLanguage };
 }
 
-export function getCommonAiOptions(config: ConfigManager) {
+export function getCommonAiOptions(config: ConfigManager, logger: LogWriter) {
   const model = config.get<string>("ai.model");
 
-  console.log(`⭐ Using model ${model}`);
+  logger.message(`⭐ Using model ${model}`);
 
   const maxTokens = config.get<number>("ai.maxTokens");
 
@@ -127,17 +145,17 @@ export function getWriteOption(config: ConfigManager) {
   return config.get<boolean>("ai.write");
 }
 
-export function getRateLimitOptions(config: ConfigManager) {
+export function getRateLimitOptions(config: ConfigManager, logger: LogWriter) {
   const requestRate = config.get<number>("ai.rate.requests");
 
   if (requestRate > 0) {
-    console.log(`⏳ Rate limiting to ${requestRate} requests per minute`);
+    logger.message(`⏳ Rate limiting to ${requestRate} requests per minute`);
   }
 
   const tokenRate = config.get<number>("ai.rate.tokens");
 
   if (tokenRate > 0) {
-    console.log(`⏳ Rate limiting to ${tokenRate} tokens per minute`);
+    logger.message(`⏳ Rate limiting to ${tokenRate} tokens per minute`);
   }
 
   return {
@@ -150,20 +168,24 @@ export function getExemplars(
   baseDir: string,
   defaultLanguage: Language,
   config: ConfigManager,
-) {
-  const exemplars = config.get<string[]>("ai.exemplars");
+): Exemplar[] {
+  const exemplarPaths = config.get<string[]>("ai.exemplars");
 
-  const exemplarFiles: TreeNode[] = [];
+  const exemplars: Exemplar[] = [];
 
-  for (const exemplar of exemplars) {
-    const moreFiles = getFlattenedTree(
-      buildPath(exemplar as string, baseDir),
+  for (const exemplar of exemplarPaths) {
+    const tree = new MarkdownTree(
+      buildPath(exemplar, baseDir),
       defaultLanguage.code,
     );
-    exemplarFiles.push(...moreFiles);
+
+    exemplars.push({
+      path: exemplar,
+      nodes: tree.getFlattenedTree(),
+    });
   }
 
-  return exemplarFiles;
+  return exemplars;
 }
 
 export function getContextStrategy(config: ConfigManager) {
@@ -178,13 +200,14 @@ export function getStyleGuides(
   baseDir: string,
   config: ConfigManager,
   defaultLanguage: Language,
+  logger: LogWriter,
   languages?: Language[],
 ): string[] {
   const styleGuides = config.get<string[]>("ai.styleGuides");
   const styleGuideFiles: string[] = [];
 
   if (styleGuides.length > 0) {
-    console.log(`📚 Using style guides:`);
+    logger.message(`📚 Using style guides:`);
 
     for (const styleGuidePath of styleGuides) {
       const resolvedPath = buildPath(styleGuidePath, baseDir);
@@ -200,7 +223,7 @@ export function getStyleGuides(
       }
 
       if (stats.isDirectory()) {
-        console.log(`  - ${styleGuidePath}/`);
+        logger.message(`  - ${styleGuidePath}/`);
 
         const tree = new MarkdownTree(resolvedPath, defaultLanguage.code);
 
@@ -208,7 +231,7 @@ export function getStyleGuides(
           const contentFiles = tree.getContent(language.code);
 
           for (const contentFile of contentFiles) {
-            console.log(
+            logger.message(
               `  -> ${printRelativePath(contentFile.path, resolvedPath)}`,
             );
 
@@ -216,7 +239,7 @@ export function getStyleGuides(
           }
         }
       } else {
-        console.log(`  - ${styleGuidePath}`);
+        logger.message(`  - ${styleGuidePath}`);
 
         const content = fs.readFileSync(resolvedPath, "utf8");
 
@@ -236,24 +259,29 @@ export function shouldEnableCache(contextStrategy: ContextStrategy) {
   return true;
 }
 
-type CommandAction<T> = (content: string, options: T) => Promise<void>;
+type CommandAction<T> = (
+  content: string,
+  options: T,
+  logger: LogWriter,
+) => Promise<void>;
 
 export function withErrorHandling<T>(
   actionName: string,
   action: CommandAction<T>,
+  logger: LogWriter = new ConsoleLogger(),
 ): CommandAction<T> {
   return async (content: string, options: T) => {
     try {
-      await action(content, options);
+      await action(content, options, logger);
     } catch (error) {
-      console.error(`\n\n❌ ${actionName} failed:`);
+      logger.error(`\n\n❌ ${actionName} failed:`);
       if (error instanceof Error) {
-        console.error(chalk.red(`Error: ${error.message}`));
+        logger.error(chalk.red(`Error: ${error.message}`));
         if (process.env.NODE_ENV === "development") {
-          console.error(chalk.gray(error.stack));
+          logger.error(chalk.gray(error.stack));
         }
       } else {
-        console.error(chalk.red("An unexpected error occurred"));
+        logger.error(chalk.red("An unexpected error occurred"));
       }
       process.exit(1);
     }
@@ -297,7 +325,7 @@ export function printTokenUsage(usage: TokenUsage) {
 export function optionForConfigSchema(
   command: Command,
   // biome-ignore lint/suspicious/noExplicitAny: Better handling of zod?
-  schema: z.ZodDefault<any>,
+  schema: z.ZodDefault<any> | z.ZodOptional<any>,
 ) {
   const flags = camelToOptionFlag(schema.cli);
 
@@ -316,12 +344,22 @@ export function optionForConfigSchema(
   return command.addOption(option);
 }
 
-// biome-ignore lint/suspicious/noExplicitAny: Better handling of zod?
-export function optionDescriptionFromSchema(schema: z.ZodDefault<any>) {
+export function optionDescriptionFromSchema(
+  // biome-ignore lint/suspicious/noExplicitAny: Better way?
+  schema: z.ZodDefault<any> | z.ZodOptional<any>,
+) {
   const env = schema.envPrefix ? `${schema.envPrefix}_*` : schema.env;
-  return `${schema.description} (${env}) (default: ${JSON.stringify(
-    schema._def.defaultValue(),
-  )})`;
+
+  let defaultValue = "";
+
+  if (schema instanceof ZodDefault) {
+    defaultValue = `(default: ${
+      // biome-ignore lint/suspicious/noExplicitAny: Better way?
+      JSON.stringify((schema as ZodDefault<any>)._def.defaultValue())
+    })`;
+  }
+
+  return `${schema.description} (${env}) ${defaultValue}`;
 }
 
 /**

--- a/src/config/manager.ts
+++ b/src/config/manager.ts
@@ -32,7 +32,14 @@ export class ConfigManager {
   private configFilePath: string | null = null;
   private cliOptions: any = {};
 
-  constructor(private schema = configSchema) {}
+  constructor(
+    private cwd: string,
+    private schema = configSchema,
+  ) {}
+
+  public getCwd() {
+    return this.cwd;
+  }
 
   /**
    * Initialize the configuration manager by loading config files
@@ -193,7 +200,7 @@ export class ConfigManager {
       // 2. Try current directory
       if (!configFilePath) {
         for (const fileName of CONFIG_FILE_NAMES) {
-          const filePath = path.join(process.cwd(), fileName);
+          const filePath = path.join(this.cwd, fileName);
           if (fs.existsSync(filePath)) {
             configFilePath = filePath;
             break;
@@ -243,6 +250,3 @@ export class ConfigManager {
     return current === undefined ? (defaultValue as T) : (current as T);
   }
 }
-
-// Export a singleton instance
-export const zodNativeConfigManager = new ConfigManager();

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -44,13 +44,13 @@ function withConfig<T extends z.ZodType>(
   return schema;
 }
 
-export const CONFIG_BASE_DIR = withConfig(
+export const CONFIG_CONTENT_DIR = withConfig(
   z
     .string()
-    .describe("Directory to use as a base for other paths")
-    .default("."),
-  "baseDir",
-  "TKMD_BASE_DIR",
+    .describe("Directory relative to the cwd where content is hosted")
+    .optional(),
+  "contentDir",
+  "TKMD_CONTENT_DIR",
 );
 
 export const CONFIG_LANGUAGE = withConfig(
@@ -135,6 +135,12 @@ export const CONFIG_REVIEW_SUMMARY_PATH = withConfig(
   "TKMD_AI_REVIEW_SUMMARY_PATH",
 );
 
+export const CONFIG_REVIEW_INSTRUCTIONS = withConfig(
+  z.string().describe("Additional instructions for the model").optional(),
+  "instructions",
+  "TKMD_REVIEW_INSTRUCTIONS",
+);
+
 export const CONFIG_FORCE_TRANSLATION = withConfig(
   z
     .boolean()
@@ -181,7 +187,7 @@ export const CONFIG_STYLE_GUIDES = withConfig(
 
 // Define the configuration schema using Zod's native description functionality
 export const configSchema = z.object({
-  baseDir: CONFIG_BASE_DIR,
+  contentDir: CONFIG_CONTENT_DIR,
   language: CONFIG_LANGUAGE,
   defaultLanguage: CONFIG_DEFAULT_LANGUAGE,
   ai: z.object({
@@ -197,6 +203,7 @@ export const configSchema = z.object({
     styleGuides: CONFIG_STYLE_GUIDES,
     review: z.object({
       summaryPath: CONFIG_REVIEW_SUMMARY_PATH,
+      instructions: CONFIG_REVIEW_INSTRUCTIONS,
     }),
     translation: z.object({
       force: CONFIG_FORCE_TRANSLATION,

--- a/tests/ai/prompts/translatePrompt.test.ts
+++ b/tests/ai/prompts/translatePrompt.test.ts
@@ -15,6 +15,7 @@
  */
 
 import { describe, expect, test, vi } from "vitest";
+import type { Exemplar } from "../../../src/ai/index.js";
 import { buildTranslatePrompt } from "../../../src/ai/prompts/translatePrompt";
 import type {
   LanguageContent,
@@ -42,6 +43,7 @@ describe("buildTranslatePrompt", () => {
     content,
     frontmatter: {},
     path: "/mock/path.md",
+    relativePath: "/mock/path.md",
     hash,
   });
 
@@ -52,6 +54,8 @@ describe("buildTranslatePrompt", () => {
   ): TreeNode => ({
     name: "mock-node",
     path,
+    relativePath: path,
+    isIndexPage: false,
     isDirectory: false,
     weight: 0,
     languages: new Map([[languageCode, createMockLanguageContent(content)]]),
@@ -166,8 +170,9 @@ describe("buildTranslatePrompt", () => {
       [],
     );
 
-    expect(result.context).toContain("The content to review is written in");
-    expect(result.context).toContain("English (United States)");
+    expect(result.context).toContain(
+      "The content is written in English (United States) provided in Markdown format below",
+    );
     expect(tree.getFlattenedTree).toHaveBeenCalled();
   });
 
@@ -256,6 +261,12 @@ describe("buildTranslatePrompt", () => {
         "# Good Example\nThis is a good example.",
       ),
     ];
+    const exemplars: Exemplar[] = [
+      {
+        path: "/examples",
+        nodes: exemplarNodes,
+      },
+    ];
 
     const result = buildTranslatePrompt(
       tree,
@@ -266,10 +277,10 @@ describe("buildTranslatePrompt", () => {
       mockTargetLanguage,
       "nothing",
       [],
-      exemplarNodes,
+      exemplars,
     );
 
-    expect(result.context).toContain("example_files");
+    expect(result.context).toContain('<example path="/examples">');
     expect(result.context).toContain("Good Example");
     expect(result.context).toContain("This is a good example.");
   });

--- a/tests/config/manager.test.ts
+++ b/tests/config/manager.test.ts
@@ -26,7 +26,7 @@ describe("ZodConfigManager", () => {
     process.env = { ...originalEnv };
 
     // Create a new ZodConfigManager with the test schema
-    configManager = new ConfigManager(configSchema);
+    configManager = new ConfigManager(process.cwd(), configSchema);
   });
 
   afterEach(() => {

--- a/tests/content/md.test.ts
+++ b/tests/content/md.test.ts
@@ -24,7 +24,9 @@ describe("MarkdownTree", () => {
       expect(result).toEqual({
         name: "test-root",
         path: rootPath,
+        relativePath: "",
         isDirectory: true,
+        isIndexPage: false,
         weight: 0,
         languages: new Map(),
         children: [],

--- a/yarn.lock
+++ b/yarn.lock
@@ -561,6 +561,7 @@ __metadata:
   dependencies:
     "@aws-sdk/client-bedrock-runtime": "npm:^3.785.0"
     "@biomejs/biome": "npm:^2.0.6"
+    "@modelcontextprotocol/sdk": "npm:^1.18.2"
     "@semantic-release/changelog": "npm:^6.0.3"
     "@semantic-release/git": "npm:^10.0.1"
     "@semantic-release/github": "npm:^11.0.3"
@@ -590,7 +591,7 @@ __metadata:
     typescript: "npm:^5.5.4"
     vitest: "npm:^3.2.4"
     yaml: "npm:^2.8.0"
-    zod: "npm:^3.25.68"
+    zod: "npm:^3.25.75"
   bin:
     toolkit-md: ./dist/cli.js
   languageName: unknown
@@ -954,6 +955,26 @@ __metadata:
     "@jridgewell/resolve-uri": "npm:^3.0.3"
     "@jridgewell/sourcemap-codec": "npm:^1.4.10"
   checksum: 10c0/fa425b606d7c7ee5bfa6a31a7b050dd5814b4082f318e0e4190f991902181b4330f43f4805db1dd4f2433fd0ed9cc7a7b9c2683f1deeab1df1b0a98b1e24055b
+  languageName: node
+  linkType: hard
+
+"@modelcontextprotocol/sdk@npm:^1.18.2":
+  version: 1.18.2
+  resolution: "@modelcontextprotocol/sdk@npm:1.18.2"
+  dependencies:
+    ajv: "npm:^6.12.6"
+    content-type: "npm:^1.0.5"
+    cors: "npm:^2.8.5"
+    cross-spawn: "npm:^7.0.5"
+    eventsource: "npm:^3.0.2"
+    eventsource-parser: "npm:^3.0.0"
+    express: "npm:^5.0.1"
+    express-rate-limit: "npm:^7.5.0"
+    pkce-challenge: "npm:^5.0.0"
+    raw-body: "npm:^3.0.0"
+    zod: "npm:^3.23.8"
+    zod-to-json-schema: "npm:^3.24.1"
+  checksum: 10c0/f0cb7a97ff264cbd389753b038c7dd197f359445324a7d4eb1d8e9be2cfb1e19d6375a12098cdd71c06847e9978c976950fc17f8d4f5e7778dd99d6f9416a48e
   languageName: node
   linkType: hard
 
@@ -2520,6 +2541,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"accepts@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "accepts@npm:2.0.0"
+  dependencies:
+    mime-types: "npm:^3.0.0"
+    negotiator: "npm:^1.0.0"
+  checksum: 10c0/98374742097e140891546076215f90c32644feacf652db48412329de4c2a529178a81aa500fbb13dd3e6cbf6e68d829037b123ac037fc9a08bcec4b87b358eef
+  languageName: node
+  linkType: hard
+
 "acorn-walk@npm:^8.1.1":
   version: 8.3.4
   resolution: "acorn-walk@npm:8.3.4"
@@ -2562,6 +2593,18 @@ __metadata:
     clean-stack: "npm:^5.2.0"
     indent-string: "npm:^5.0.0"
   checksum: 10c0/a5de7138571f514bad76290736f49a0db8809247082f2519037e0c37d03fc8d91d733e079d6b1674feda28a757b1932421ad205b8c0f8794a0c0e5bf1be2315e
+  languageName: node
+  linkType: hard
+
+"ajv@npm:^6.12.6":
+  version: 6.12.6
+  resolution: "ajv@npm:6.12.6"
+  dependencies:
+    fast-deep-equal: "npm:^3.1.1"
+    fast-json-stable-stringify: "npm:^2.0.0"
+    json-schema-traverse: "npm:^0.4.1"
+    uri-js: "npm:^4.2.2"
+  checksum: 10c0/41e23642cbe545889245b9d2a45854ebba51cda6c778ebced9649420d9205f2efb39cb43dbc41e358409223b1ea43303ae4839db682c848b891e4811da1a5a71
   languageName: node
   linkType: hard
 
@@ -2779,6 +2822,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"body-parser@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "body-parser@npm:2.2.0"
+  dependencies:
+    bytes: "npm:^3.1.2"
+    content-type: "npm:^1.0.5"
+    debug: "npm:^4.4.0"
+    http-errors: "npm:^2.0.0"
+    iconv-lite: "npm:^0.6.3"
+    on-finished: "npm:^2.4.1"
+    qs: "npm:^6.14.0"
+    raw-body: "npm:^3.0.0"
+    type-is: "npm:^2.0.0"
+  checksum: 10c0/a9ded39e71ac9668e2211afa72e82ff86cc5ef94de1250b7d1ba9cc299e4150408aaa5f1e8b03dd4578472a3ce6d1caa2a23b27a6c18e526e48b4595174c116c
+  languageName: node
+  linkType: hard
+
 "bottleneck@npm:^2.15.3":
   version: 2.19.5
   resolution: "bottleneck@npm:2.19.5"
@@ -2821,6 +2881,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"bytes@npm:3.1.2, bytes@npm:^3.1.2":
+  version: 3.1.2
+  resolution: "bytes@npm:3.1.2"
+  checksum: 10c0/76d1c43cbd602794ad8ad2ae94095cddeb1de78c5dddaa7005c51af10b0176c69971a6d88e805a90c2b6550d76636e43c40d8427a808b8645ede885de4a0358e
+  languageName: node
+  linkType: hard
+
 "cac@npm:^6.7.14":
   version: 6.7.14
   resolution: "cac@npm:6.7.14"
@@ -2845,6 +2912,26 @@ __metadata:
     tar: "npm:^7.4.3"
     unique-filename: "npm:^4.0.0"
   checksum: 10c0/01f2134e1bd7d3ab68be851df96c8d63b492b1853b67f2eecb2c37bb682d37cb70bb858a16f2f0554d3c0071be6dfe21456a1ff6fa4b7eed996570d6a25ffe9c
+  languageName: node
+  linkType: hard
+
+"call-bind-apply-helpers@npm:^1.0.1, call-bind-apply-helpers@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "call-bind-apply-helpers@npm:1.0.2"
+  dependencies:
+    es-errors: "npm:^1.3.0"
+    function-bind: "npm:^1.1.2"
+  checksum: 10c0/47bd9901d57b857590431243fea704ff18078b16890a6b3e021e12d279bbf211d039155e27d7566b374d49ee1f8189344bac9833dec7a20cdec370506361c938
+  languageName: node
+  linkType: hard
+
+"call-bound@npm:^1.0.2":
+  version: 1.0.4
+  resolution: "call-bound@npm:1.0.4"
+  dependencies:
+    call-bind-apply-helpers: "npm:^1.0.2"
+    get-intrinsic: "npm:^1.3.0"
+  checksum: 10c0/f4796a6a0941e71c766aea672f63b72bc61234c4f4964dc6d7606e3664c307e7d77845328a8f3359ce39ddb377fed67318f9ee203dea1d47e46165dcf2917644
   languageName: node
   linkType: hard
 
@@ -3172,6 +3259,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"content-disposition@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "content-disposition@npm:1.0.0"
+  dependencies:
+    safe-buffer: "npm:5.2.1"
+  checksum: 10c0/c7b1ba0cea2829da0352ebc1b7f14787c73884bc707c8bc2271d9e3bf447b372270d09f5d3980dc5037c749ceef56b9a13fccd0b0001c87c3f12579967e4dd27
+  languageName: node
+  linkType: hard
+
+"content-type@npm:^1.0.5":
+  version: 1.0.5
+  resolution: "content-type@npm:1.0.5"
+  checksum: 10c0/b76ebed15c000aee4678c3707e0860cb6abd4e680a598c0a26e17f0bfae723ec9cc2802f0ff1bc6e4d80603719010431d2231018373d4dde10f9ccff9dadf5af
+  languageName: node
+  linkType: hard
+
 "conventional-changelog-angular@npm:^8.0.0":
   version: 8.0.0
   resolution: "conventional-changelog-angular@npm:8.0.0"
@@ -3220,10 +3323,34 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cookie-signature@npm:^1.2.1":
+  version: 1.2.2
+  resolution: "cookie-signature@npm:1.2.2"
+  checksum: 10c0/54e05df1a293b3ce81589b27dddc445f462f6fa6812147c033350cd3561a42bc14481674e05ed14c7bd0ce1e8bb3dc0e40851bad75415733711294ddce0b7bc6
+  languageName: node
+  linkType: hard
+
+"cookie@npm:^0.7.1":
+  version: 0.7.2
+  resolution: "cookie@npm:0.7.2"
+  checksum: 10c0/9596e8ccdbf1a3a88ae02cf5ee80c1c50959423e1022e4e60b91dd87c622af1da309253d8abdb258fb5e3eacb4f08e579dc58b4897b8087574eee0fd35dfa5d2
+  languageName: node
+  linkType: hard
+
 "core-util-is@npm:~1.0.0":
   version: 1.0.3
   resolution: "core-util-is@npm:1.0.3"
   checksum: 10c0/90a0e40abbddfd7618f8ccd63a74d88deea94e77d0e8dbbea059fa7ebebb8fbb4e2909667fe26f3a467073de1a542ebe6ae4c73a73745ac5833786759cd906c9
+  languageName: node
+  linkType: hard
+
+"cors@npm:^2.8.5":
+  version: 2.8.5
+  resolution: "cors@npm:2.8.5"
+  dependencies:
+    object-assign: "npm:^4"
+    vary: "npm:^1"
+  checksum: 10c0/373702b7999409922da80de4a61938aabba6929aea5b6fd9096fefb9e8342f626c0ebd7507b0e8b0b311380744cc985f27edebc0a26e0ddb784b54e1085de761
   languageName: node
   linkType: hard
 
@@ -3251,7 +3378,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-spawn@npm:^7.0.3, cross-spawn@npm:^7.0.6":
+"cross-spawn@npm:^7.0.3, cross-spawn@npm:^7.0.5, cross-spawn@npm:^7.0.6":
   version: 7.0.6
   resolution: "cross-spawn@npm:7.0.6"
   dependencies:
@@ -3280,7 +3407,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.0.0, debug@npm:^4.3.4, debug@npm:^4.4.1":
+"debug@npm:4, debug@npm:^4.0.0, debug@npm:^4.3.4, debug@npm:^4.3.5, debug@npm:^4.4.0, debug@npm:^4.4.1":
   version: 4.4.1
   resolution: "debug@npm:4.4.1"
   dependencies:
@@ -3346,6 +3473,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"depd@npm:2.0.0, depd@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "depd@npm:2.0.0"
+  checksum: 10c0/58bd06ec20e19529b06f7ad07ddab60e504d9e0faca4bd23079fac2d279c3594334d736508dc350e06e510aba5e22e4594483b3a6562ce7c17dd797f4cc4ad2c
+  languageName: node
+  linkType: hard
+
 "dezalgo@npm:^1.0.0":
   version: 1.0.4
   resolution: "dezalgo@npm:1.0.4"
@@ -3395,6 +3529,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dunder-proto@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "dunder-proto@npm:1.0.1"
+  dependencies:
+    call-bind-apply-helpers: "npm:^1.0.1"
+    es-errors: "npm:^1.3.0"
+    gopd: "npm:^1.2.0"
+  checksum: 10c0/199f2a0c1c16593ca0a145dbf76a962f8033ce3129f01284d48c45ed4e14fea9bbacd7b3610b6cdc33486cef20385ac054948fefc6272fcce645c09468f93031
+  languageName: node
+  linkType: hard
+
 "duplexer2@npm:~0.1.0":
   version: 0.1.4
   resolution: "duplexer2@npm:0.1.4"
@@ -3408,6 +3553,13 @@ __metadata:
   version: 0.2.0
   resolution: "eastasianwidth@npm:0.2.0"
   checksum: 10c0/26f364ebcdb6395f95124fda411f63137a4bfb5d3a06453f7f23dfe52502905bd84e0488172e0f9ec295fdc45f05c23d5d91baf16bd26f0fe9acd777a188dc39
+  languageName: node
+  linkType: hard
+
+"ee-first@npm:1.1.1":
+  version: 1.1.1
+  resolution: "ee-first@npm:1.1.1"
+  checksum: 10c0/b5bb125ee93161bc16bfe6e56c6b04de5ad2aa44234d8f644813cc95d861a6910903132b05093706de2b706599367c4130eb6d170f6b46895686b95f87d017b7
   languageName: node
   linkType: hard
 
@@ -3436,6 +3588,13 @@ __metadata:
   version: 2.4.0
   resolution: "emojilib@npm:2.4.0"
   checksum: 10c0/6e66ba8921175842193f974e18af448bb6adb0cf7aeea75e08b9d4ea8e9baba0e4a5347b46ed901491dcaba277485891c33a8d70b0560ca5cc9672a94c21ab8f
+  languageName: node
+  linkType: hard
+
+"encodeurl@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "encodeurl@npm:2.0.0"
+  checksum: 10c0/5d317306acb13e6590e28e27924c754163946a2480de11865c991a3a7eed4315cd3fba378b543ca145829569eefe9b899f3d84bb09870f675ae60bc924b01ceb
   languageName: node
   linkType: hard
 
@@ -3488,10 +3647,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"es-define-property@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "es-define-property@npm:1.0.1"
+  checksum: 10c0/3f54eb49c16c18707949ff25a1456728c883e81259f045003499efba399c08bad00deebf65cccde8c0e07908c1a225c9d472b7107e558f2a48e28d530e34527c
+  languageName: node
+  linkType: hard
+
+"es-errors@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "es-errors@npm:1.3.0"
+  checksum: 10c0/0a61325670072f98d8ae3b914edab3559b6caa980f08054a3b872052640d91da01d38df55df797fcc916389d77fc92b8d5906cf028f4db46d7e3003abecbca85
+  languageName: node
+  linkType: hard
+
 "es-module-lexer@npm:^1.7.0":
   version: 1.7.0
   resolution: "es-module-lexer@npm:1.7.0"
   checksum: 10c0/4c935affcbfeba7fb4533e1da10fa8568043df1e3574b869385980de9e2d475ddc36769891936dbb07036edb3c3786a8b78ccf44964cd130dedc1f2c984b6c7b
+  languageName: node
+  linkType: hard
+
+"es-object-atoms@npm:^1.0.0, es-object-atoms@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "es-object-atoms@npm:1.1.1"
+  dependencies:
+    es-errors: "npm:^1.3.0"
+  checksum: 10c0/65364812ca4daf48eb76e2a3b7a89b3f6a2e62a1c420766ce9f692665a29d94fe41fe88b65f24106f449859549711e4b40d9fb8002d862dfd7eb1c512d10be0c
   languageName: node
   linkType: hard
 
@@ -3591,6 +3773,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"escape-html@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "escape-html@npm:1.0.3"
+  checksum: 10c0/524c739d776b36c3d29fa08a22e03e8824e3b2fd57500e5e44ecf3cc4707c34c60f9ca0781c0e33d191f2991161504c295e98f68c78fe7baa6e57081ec6ac0a3
+  languageName: node
+  linkType: hard
+
 "escape-string-regexp@npm:5.0.0":
   version: 5.0.0
   resolution: "escape-string-regexp@npm:5.0.0"
@@ -3621,6 +3810,29 @@ __metadata:
   dependencies:
     "@types/estree": "npm:^1.0.0"
   checksum: 10c0/c12e3c2b2642d2bcae7d5aa495c60fa2f299160946535763969a1c83fc74518ffa9c2cd3a8b69ac56aea547df6a8aac25f729a342992ef0bbac5f1c73e78995d
+  languageName: node
+  linkType: hard
+
+"etag@npm:^1.8.1":
+  version: 1.8.1
+  resolution: "etag@npm:1.8.1"
+  checksum: 10c0/12be11ef62fb9817314d790089a0a49fae4e1b50594135dcb8076312b7d7e470884b5100d249b28c18581b7fd52f8b485689ffae22a11ed9ec17377a33a08f84
+  languageName: node
+  linkType: hard
+
+"eventsource-parser@npm:^3.0.0, eventsource-parser@npm:^3.0.1":
+  version: 3.0.3
+  resolution: "eventsource-parser@npm:3.0.3"
+  checksum: 10c0/2594011630efba56cafafc8ed6bd9a50db8f6d5dd62089b0950346e7961828c16efe07a588bdea3ba79e568fd9246c8163824a2ffaade767e1fdb2270c1fae0b
+  languageName: node
+  linkType: hard
+
+"eventsource@npm:^3.0.2":
+  version: 3.0.7
+  resolution: "eventsource@npm:3.0.7"
+  dependencies:
+    eventsource-parser: "npm:^3.0.1"
+  checksum: 10c0/c48a73c38f300e33e9f11375d4ee969f25cbb0519608a12378a38068055ae8b55b6e0e8a49c3f91c784068434efe1d9f01eb49b6315b04b0da9157879ce2f67d
   languageName: node
   linkType: hard
 
@@ -3692,6 +3904,50 @@ __metadata:
   languageName: node
   linkType: hard
 
+"express-rate-limit@npm:^7.5.0":
+  version: 7.5.1
+  resolution: "express-rate-limit@npm:7.5.1"
+  peerDependencies:
+    express: ">= 4.11"
+  checksum: 10c0/b07de84d700a2c07c4bf2f040e7558ed5a1f660f03ed5f30bf8ff7b51e98ba7a85215640e70fc48cbbb9151066ea51239d9a1b41febc9b84d98c7915b0186161
+  languageName: node
+  linkType: hard
+
+"express@npm:^5.0.1":
+  version: 5.1.0
+  resolution: "express@npm:5.1.0"
+  dependencies:
+    accepts: "npm:^2.0.0"
+    body-parser: "npm:^2.2.0"
+    content-disposition: "npm:^1.0.0"
+    content-type: "npm:^1.0.5"
+    cookie: "npm:^0.7.1"
+    cookie-signature: "npm:^1.2.1"
+    debug: "npm:^4.4.0"
+    encodeurl: "npm:^2.0.0"
+    escape-html: "npm:^1.0.3"
+    etag: "npm:^1.8.1"
+    finalhandler: "npm:^2.1.0"
+    fresh: "npm:^2.0.0"
+    http-errors: "npm:^2.0.0"
+    merge-descriptors: "npm:^2.0.0"
+    mime-types: "npm:^3.0.0"
+    on-finished: "npm:^2.4.1"
+    once: "npm:^1.4.0"
+    parseurl: "npm:^1.3.3"
+    proxy-addr: "npm:^2.0.7"
+    qs: "npm:^6.14.0"
+    range-parser: "npm:^1.2.1"
+    router: "npm:^2.2.0"
+    send: "npm:^1.1.0"
+    serve-static: "npm:^2.2.0"
+    statuses: "npm:^2.0.1"
+    type-is: "npm:^2.0.1"
+    vary: "npm:^1.1.2"
+  checksum: 10c0/80ce7c53c5f56887d759b94c3f2283e2e51066c98d4b72a4cc1338e832b77f1e54f30d0239cc10815a0f849bdb753e6a284d2fa48d4ab56faf9c501f55d751d6
+  languageName: node
+  linkType: hard
+
 "extend-shallow@npm:^2.0.1":
   version: 2.0.1
   resolution: "extend-shallow@npm:2.0.1"
@@ -3708,6 +3964,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fast-deep-equal@npm:^3.1.1":
+  version: 3.1.3
+  resolution: "fast-deep-equal@npm:3.1.3"
+  checksum: 10c0/40dedc862eb8992c54579c66d914635afbec43350afbbe991235fdcb4e3a8d5af1b23ae7e79bef7d4882d0ecee06c3197488026998fb19f72dc95acff1d1b1d0
+  languageName: node
+  linkType: hard
+
 "fast-glob@npm:^3.2.9, fast-glob@npm:^3.3.3":
   version: 3.3.3
   resolution: "fast-glob@npm:3.3.3"
@@ -3718,6 +3981,13 @@ __metadata:
     merge2: "npm:^1.3.0"
     micromatch: "npm:^4.0.8"
   checksum: 10c0/f6aaa141d0d3384cf73cbcdfc52f475ed293f6d5b65bfc5def368b09163a9f7e5ec2b3014d80f733c405f58e470ee0cc451c2937685045cddcdeaa24199c43fe
+  languageName: node
+  linkType: hard
+
+"fast-json-stable-stringify@npm:^2.0.0":
+  version: 2.1.0
+  resolution: "fast-json-stable-stringify@npm:2.1.0"
+  checksum: 10c0/7f081eb0b8a64e0057b3bb03f974b3ef00135fbf36c1c710895cd9300f13c94ba809bb3a81cf4e1b03f6e5285610a61abbd7602d0652de423144dfee5a389c9b
   languageName: node
   linkType: hard
 
@@ -3797,6 +4067,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"finalhandler@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "finalhandler@npm:2.1.0"
+  dependencies:
+    debug: "npm:^4.4.0"
+    encodeurl: "npm:^2.0.0"
+    escape-html: "npm:^1.0.3"
+    on-finished: "npm:^2.4.1"
+    parseurl: "npm:^1.3.3"
+    statuses: "npm:^2.0.1"
+  checksum: 10c0/da0bbca6d03873472ee890564eb2183f4ed377f25f3628a0fc9d16dac40bed7b150a0d82ebb77356e4c6d97d2796ad2dba22948b951dddee2c8768b0d1b9fb1f
+  languageName: node
+  linkType: hard
+
 "find-up-simple@npm:^1.0.0":
   version: 1.0.1
   resolution: "find-up-simple@npm:1.0.1"
@@ -3840,6 +4124,20 @@ __metadata:
     cross-spawn: "npm:^7.0.6"
     signal-exit: "npm:^4.0.1"
   checksum: 10c0/8986e4af2430896e65bc2788d6679067294d6aee9545daefc84923a0a4b399ad9c7a3ea7bd8c0b2b80fdf4a92de4c69df3f628233ff3224260e9c1541a9e9ed3
+  languageName: node
+  linkType: hard
+
+"forwarded@npm:0.2.0":
+  version: 0.2.0
+  resolution: "forwarded@npm:0.2.0"
+  checksum: 10c0/9b67c3fac86acdbc9ae47ba1ddd5f2f81526fa4c8226863ede5600a3f7c7416ef451f6f1e240a3cc32d0fd79fcfe6beb08fd0da454f360032bde70bf80afbb33
+  languageName: node
+  linkType: hard
+
+"fresh@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "fresh@npm:2.0.0"
+  checksum: 10c0/0557548194cb9a809a435bf92bcfbc20c89e8b5eb38861b73ced36750437251e39a111fc3a18b98531be9dd91fe1411e4969f229dc579ec0251ce6c5d4900bbc
   languageName: node
   linkType: hard
 
@@ -3933,6 +4231,34 @@ __metadata:
   version: 1.3.0
   resolution: "get-east-asian-width@npm:1.3.0"
   checksum: 10c0/1a049ba697e0f9a4d5514c4623781c5246982bdb61082da6b5ae6c33d838e52ce6726407df285cdbb27ec1908b333cf2820989bd3e986e37bb20979437fdf34b
+  languageName: node
+  linkType: hard
+
+"get-intrinsic@npm:^1.2.5, get-intrinsic@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "get-intrinsic@npm:1.3.0"
+  dependencies:
+    call-bind-apply-helpers: "npm:^1.0.2"
+    es-define-property: "npm:^1.0.1"
+    es-errors: "npm:^1.3.0"
+    es-object-atoms: "npm:^1.1.1"
+    function-bind: "npm:^1.1.2"
+    get-proto: "npm:^1.0.1"
+    gopd: "npm:^1.2.0"
+    has-symbols: "npm:^1.1.0"
+    hasown: "npm:^2.0.2"
+    math-intrinsics: "npm:^1.1.0"
+  checksum: 10c0/52c81808af9a8130f581e6a6a83e1ba4a9f703359e7a438d1369a5267a25412322f03dcbd7c549edaef0b6214a0630a28511d7df0130c93cfd380f4fa0b5b66a
+  languageName: node
+  linkType: hard
+
+"get-proto@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "get-proto@npm:1.0.1"
+  dependencies:
+    dunder-proto: "npm:^1.0.1"
+    es-object-atoms: "npm:^1.0.0"
+  checksum: 10c0/9224acb44603c5526955e83510b9da41baf6ae73f7398875fba50edc5e944223a89c4a72b070fcd78beb5f7bdda58ecb6294adc28f7acfc0da05f76a2399643c
   languageName: node
   linkType: hard
 
@@ -4057,6 +4383,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"gopd@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "gopd@npm:1.2.0"
+  checksum: 10c0/50fff1e04ba2b7737c097358534eacadad1e68d24cccee3272e04e007bed008e68d2614f3987788428fd192a5ae3889d08fb2331417e4fc4a9ab366b2043cead
+  languageName: node
+  linkType: hard
+
 "graceful-fs@npm:4.2.10":
   version: 4.2.10
   resolution: "graceful-fs@npm:4.2.10"
@@ -4119,6 +4452,13 @@ __metadata:
   version: 4.0.0
   resolution: "has-flag@npm:4.0.0"
   checksum: 10c0/2e789c61b7888d66993e14e8331449e525ef42aac53c627cc53d1c3334e768bcb6abdc4f5f0de1478a25beec6f0bd62c7549058b7ac53e924040d4f301f02fd1
+  languageName: node
+  linkType: hard
+
+"has-symbols@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "has-symbols@npm:1.1.0"
+  checksum: 10c0/dde0a734b17ae51e84b10986e651c664379018d10b91b6b0e9b293eddb32f0f069688c841fb40f19e9611546130153e0a2a48fd7f512891fb000ddfa36f5a20e
   languageName: node
   linkType: hard
 
@@ -4186,6 +4526,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"http-errors@npm:2.0.0, http-errors@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "http-errors@npm:2.0.0"
+  dependencies:
+    depd: "npm:2.0.0"
+    inherits: "npm:2.0.4"
+    setprototypeof: "npm:1.2.0"
+    statuses: "npm:2.0.1"
+    toidentifier: "npm:1.0.1"
+  checksum: 10c0/fc6f2715fe188d091274b5ffc8b3657bd85c63e969daa68ccb77afb05b071a4b62841acb7a21e417b5539014dff2ebf9550f0b14a9ff126f2734a7c1387f8e19
+  languageName: node
+  linkType: hard
+
 "http-proxy-agent@npm:^7.0.0":
   version: 7.0.2
   resolution: "http-proxy-agent@npm:7.0.2"
@@ -4227,7 +4580,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"iconv-lite@npm:^0.6.2":
+"iconv-lite@npm:0.6.3, iconv-lite@npm:^0.6.2, iconv-lite@npm:^0.6.3":
   version: 0.6.3
   resolution: "iconv-lite@npm:0.6.3"
   dependencies:
@@ -4324,7 +4677,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"inherits@npm:2, inherits@npm:^2.0.1, inherits@npm:~2.0.3":
+"inherits@npm:2, inherits@npm:2.0.4, inherits@npm:^2.0.1, inherits@npm:~2.0.3":
   version: 2.0.4
   resolution: "inherits@npm:2.0.4"
   checksum: 10c0/4e531f648b29039fb7426fb94075e6545faa1eb9fe83c29f0b6d9e7263aceb4289d2d4557db0d428188eeb449cc7c5e77b0a0b2c4e248ff2a65933a0dee49ef2
@@ -4391,6 +4744,13 @@ __metadata:
   version: 5.0.0
   resolution: "ip-regex@npm:5.0.0"
   checksum: 10c0/23f07cf393436627b3a91f7121eee5bc831522d07c95ddd13f5a6f7757698b08551480f12e5dbb3bf248724da135d54405c9687733dba7314f74efae593bdf06
+  languageName: node
+  linkType: hard
+
+"ipaddr.js@npm:1.9.1":
+  version: 1.9.1
+  resolution: "ipaddr.js@npm:1.9.1"
+  checksum: 10c0/0486e775047971d3fdb5fb4f063829bac45af299ae0b82dcf3afa2145338e08290563a2a70f34b732d795ecc8311902e541a8530eeb30d75860a78ff4e94ce2a
   languageName: node
   linkType: hard
 
@@ -4490,6 +4850,13 @@ __metadata:
   version: 4.1.0
   resolution: "is-plain-obj@npm:4.1.0"
   checksum: 10c0/32130d651d71d9564dc88ba7e6fda0e91a1010a3694648e9f4f47bb6080438140696d3e3e15c741411d712e47ac9edc1a8a9de1fe76f3487b0d90be06ac9975e
+  languageName: node
+  linkType: hard
+
+"is-promise@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "is-promise@npm:4.0.0"
+  checksum: 10c0/ebd5c672d73db781ab33ccb155fb9969d6028e37414d609b115cc534654c91ccd061821d5b987eefaa97cf4c62f0b909bb2f04db88306de26e91bfe8ddc01503
   languageName: node
   linkType: hard
 
@@ -4644,6 +5011,13 @@ __metadata:
   version: 4.0.0
   resolution: "json-parse-even-better-errors@npm:4.0.0"
   checksum: 10c0/84cd9304a97e8fb2af3937bf53acb91c026aeb859703c332684e688ea60db27fc2242aa532a84e1883fdcbe1e5c1fb57c2bef38e312021aa1cd300defc63cf16
+  languageName: node
+  linkType: hard
+
+"json-schema-traverse@npm:^0.4.1":
+  version: 0.4.1
+  resolution: "json-schema-traverse@npm:0.4.1"
+  checksum: 10c0/108fa90d4cc6f08243aedc6da16c408daf81793bf903e9fd5ab21983cda433d5d2da49e40711da016289465ec2e62e0324dcdfbc06275a607fe3233fde4942ce
   languageName: node
   linkType: hard
 
@@ -5168,6 +5542,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"math-intrinsics@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "math-intrinsics@npm:1.1.0"
+  checksum: 10c0/7579ff94e899e2f76ab64491d76cf606274c874d8f2af4a442c016bd85688927fcfca157ba6bf74b08e9439dc010b248ce05b96cc7c126a354c3bae7fcb48b7f
+  languageName: node
+  linkType: hard
+
+"media-typer@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "media-typer@npm:1.1.0"
+  checksum: 10c0/7b4baa40b25964bb90e2121ee489ec38642127e48d0cc2b6baa442688d3fde6262bfdca86d6bbf6ba708784afcac168c06840c71facac70e390f5f759ac121b9
+  languageName: node
+  linkType: hard
+
 "meow@npm:^10.1.2":
   version: 10.1.5
   resolution: "meow@npm:10.1.5"
@@ -5195,6 +5583,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"merge-descriptors@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "merge-descriptors@npm:2.0.0"
+  checksum: 10c0/95389b7ced3f9b36fbdcf32eb946dc3dd1774c2fdf164609e55b18d03aa499b12bd3aae3a76c1c7185b96279e9803525550d3eb292b5224866060a288f335cb3
+  languageName: node
+  linkType: hard
+
 "merge-stream@npm:^2.0.0":
   version: 2.0.0
   resolution: "merge-stream@npm:2.0.0"
@@ -5216,6 +5611,22 @@ __metadata:
     braces: "npm:^3.0.3"
     picomatch: "npm:^2.3.1"
   checksum: 10c0/166fa6eb926b9553f32ef81f5f531d27b4ce7da60e5baf8c021d043b27a388fb95e46a8038d5045877881e673f8134122b59624d5cecbd16eb50a42e7a6b5ca8
+  languageName: node
+  linkType: hard
+
+"mime-db@npm:^1.54.0":
+  version: 1.54.0
+  resolution: "mime-db@npm:1.54.0"
+  checksum: 10c0/8d907917bc2a90fa2df842cdf5dfeaf509adc15fe0531e07bb2f6ab15992416479015828d6a74200041c492e42cce3ebf78e5ce714388a0a538ea9c53eece284
+  languageName: node
+  linkType: hard
+
+"mime-types@npm:^3.0.0, mime-types@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "mime-types@npm:3.0.1"
+  dependencies:
+    mime-db: "npm:^1.54.0"
+  checksum: 10c0/bd8c20d3694548089cf229016124f8f40e6a60bbb600161ae13e45f793a2d5bb40f96bbc61f275836696179c77c1d6bf4967b2a75e0a8ad40fe31f4ed5be4da5
   languageName: node
   linkType: hard
 
@@ -5823,14 +6234,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object-assign@npm:^4.0.1":
+"object-assign@npm:^4, object-assign@npm:^4.0.1":
   version: 4.1.1
   resolution: "object-assign@npm:4.1.1"
   checksum: 10c0/1f4df9945120325d041ccf7b86f31e8bcc14e73d29171e37a7903050e96b81323784ec59f93f102ec635bcf6fa8034ba3ea0a8c7e69fa202b87ae3b6cec5a414
   languageName: node
   linkType: hard
 
-"once@npm:^1.3.0":
+"object-inspect@npm:^1.13.3":
+  version: 1.13.4
+  resolution: "object-inspect@npm:1.13.4"
+  checksum: 10c0/d7f8711e803b96ea3191c745d6f8056ce1f2496e530e6a19a0e92d89b0fa3c76d910c31f0aa270432db6bd3b2f85500a376a83aaba849a8d518c8845b3211692
+  languageName: node
+  linkType: hard
+
+"on-finished@npm:^2.4.1":
+  version: 2.4.1
+  resolution: "on-finished@npm:2.4.1"
+  dependencies:
+    ee-first: "npm:1.1.1"
+  checksum: 10c0/46fb11b9063782f2d9968863d9cbba33d77aa13c17f895f56129c274318b86500b22af3a160fe9995aa41317efcd22941b6eba747f718ced08d9a73afdb087b4
+  languageName: node
+  linkType: hard
+
+"once@npm:^1.3.0, once@npm:^1.4.0":
   version: 1.4.0
   resolution: "once@npm:1.4.0"
   dependencies:
@@ -6138,6 +6565,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"parseurl@npm:^1.3.3":
+  version: 1.3.3
+  resolution: "parseurl@npm:1.3.3"
+  checksum: 10c0/90dd4760d6f6174adb9f20cf0965ae12e23879b5f5464f38e92fce8073354341e4b3b76fa3d878351efe7d01e617121955284cfd002ab087fba1a0726ec0b4f5
+  languageName: node
+  linkType: hard
+
 "path-exists@npm:^3.0.0":
   version: 3.0.0
   resolution: "path-exists@npm:3.0.0"
@@ -6190,7 +6624,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-to-regexp@npm:^8.1.0":
+"path-to-regexp@npm:^8.0.0, path-to-regexp@npm:^8.1.0":
   version: 8.2.0
   resolution: "path-to-regexp@npm:8.2.0"
   checksum: 10c0/ef7d0a887b603c0a142fad16ccebdcdc42910f0b14830517c724466ad676107476bba2fe9fffd28fd4c141391ccd42ea426f32bb44c2c82ecaefe10c37b90f5a
@@ -6250,6 +6684,13 @@ __metadata:
   version: 3.0.0
   resolution: "pify@npm:3.0.0"
   checksum: 10c0/fead19ed9d801f1b1fcd0638a1ac53eabbb0945bf615f2f8806a8b646565a04a1b0e7ef115c951d225f042cca388fdc1cd3add46d10d1ed6951c20bd2998af10
+  languageName: node
+  linkType: hard
+
+"pkce-challenge@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "pkce-challenge@npm:5.0.0"
+  checksum: 10c0/c6706d627fdbb6f22bf8cc5d60d96d6b6a7bb481399b336a3d3f4e9bfba3e167a2c32f8ec0b5e74be686a0ba3bcc9894865d4c2dd1b91cea4c05dba1f28602c3
   languageName: node
   linkType: hard
 
@@ -6363,12 +6804,38 @@ __metadata:
   languageName: node
   linkType: hard
 
+"proxy-addr@npm:^2.0.7":
+  version: 2.0.7
+  resolution: "proxy-addr@npm:2.0.7"
+  dependencies:
+    forwarded: "npm:0.2.0"
+    ipaddr.js: "npm:1.9.1"
+  checksum: 10c0/c3eed999781a35f7fd935f398b6d8920b6fb00bbc14287bc6de78128ccc1a02c89b95b56742bf7cf0362cc333c61d138532049c7dedc7a328ef13343eff81210
+  languageName: node
+  linkType: hard
+
+"punycode@npm:^2.1.0":
+  version: 2.3.1
+  resolution: "punycode@npm:2.3.1"
+  checksum: 10c0/14f76a8206bc3464f794fb2e3d3cc665ae416c01893ad7a02b23766eb07159144ee612ad67af5e84fa4479ccfe67678c4feb126b0485651b302babf66f04f9e9
+  languageName: node
+  linkType: hard
+
 "qrcode-terminal@npm:^0.12.0":
   version: 0.12.0
   resolution: "qrcode-terminal@npm:0.12.0"
   bin:
     qrcode-terminal: ./bin/qrcode-terminal.js
   checksum: 10c0/1d8996a743d6c95e22056bd45fe958c306213adc97d7ef8cf1e03bc1aeeb6f27180a747ec3d761141921351eb1e3ca688f7b673ab54cdae9fa358dffaa49563c
+  languageName: node
+  linkType: hard
+
+"qs@npm:^6.14.0":
+  version: 6.14.0
+  resolution: "qs@npm:6.14.0"
+  dependencies:
+    side-channel: "npm:^1.1.0"
+  checksum: 10c0/8ea5d91bf34f440598ee389d4a7d95820e3b837d3fd9f433871f7924801becaa0cd3b3b4628d49a7784d06a8aea9bc4554d2b6d8d584e2d221dc06238a42909c
   languageName: node
   linkType: hard
 
@@ -6390,6 +6857,25 @@ __metadata:
   version: 5.1.1
   resolution: "quick-lru@npm:5.1.1"
   checksum: 10c0/a24cba5da8cec30d70d2484be37622580f64765fb6390a928b17f60cd69e8dbd32a954b3ff9176fa1b86d86ff2ba05252fae55dc4d40d0291c60412b0ad096da
+  languageName: node
+  linkType: hard
+
+"range-parser@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "range-parser@npm:1.2.1"
+  checksum: 10c0/96c032ac2475c8027b7a4e9fe22dc0dfe0f6d90b85e496e0f016fbdb99d6d066de0112e680805075bd989905e2123b3b3d002765149294dce0c1f7f01fcc2ea0
+  languageName: node
+  linkType: hard
+
+"raw-body@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "raw-body@npm:3.0.0"
+  dependencies:
+    bytes: "npm:3.1.2"
+    http-errors: "npm:2.0.0"
+    iconv-lite: "npm:0.6.3"
+    unpipe: "npm:1.0.0"
+  checksum: 10c0/f8daf4b724064a4811d118745a781ca0fb4676298b8adadfd6591155549cfea0a067523cf7dd3baeb1265fecc9ce5dfb2fc788c12c66b85202a336593ece0f87
   languageName: node
   linkType: hard
 
@@ -6727,12 +7213,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"router@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "router@npm:2.2.0"
+  dependencies:
+    debug: "npm:^4.4.0"
+    depd: "npm:^2.0.0"
+    is-promise: "npm:^4.0.0"
+    parseurl: "npm:^1.3.3"
+    path-to-regexp: "npm:^8.0.0"
+  checksum: 10c0/3279de7450c8eae2f6e095e9edacbdeec0abb5cb7249c6e719faa0db2dba43574b4fff5892d9220631c9abaff52dd3cad648cfea2aaace845e1a071915ac8867
+  languageName: node
+  linkType: hard
+
 "run-parallel@npm:^1.1.9":
   version: 1.2.0
   resolution: "run-parallel@npm:1.2.0"
   dependencies:
     queue-microtask: "npm:^1.2.2"
   checksum: 10c0/200b5ab25b5b8b7113f9901bfe3afc347e19bb7475b267d55ad0eb86a62a46d77510cb0f232507c9e5d497ebda569a08a9867d0d14f57a82ad5564d991588b39
+  languageName: node
+  linkType: hard
+
+"safe-buffer@npm:5.2.1":
+  version: 5.2.1
+  resolution: "safe-buffer@npm:5.2.1"
+  checksum: 10c0/6501914237c0a86e9675d4e51d89ca3c21ffd6a31642efeba25ad65720bce6921c9e7e974e5be91a786b25aa058b5303285d3c15dbabf983a919f5f630d349f3
   languageName: node
   linkType: hard
 
@@ -6833,6 +7339,44 @@ __metadata:
   languageName: node
   linkType: hard
 
+"send@npm:^1.1.0, send@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "send@npm:1.2.0"
+  dependencies:
+    debug: "npm:^4.3.5"
+    encodeurl: "npm:^2.0.0"
+    escape-html: "npm:^1.0.3"
+    etag: "npm:^1.8.1"
+    fresh: "npm:^2.0.0"
+    http-errors: "npm:^2.0.0"
+    mime-types: "npm:^3.0.1"
+    ms: "npm:^2.1.3"
+    on-finished: "npm:^2.4.1"
+    range-parser: "npm:^1.2.1"
+    statuses: "npm:^2.0.1"
+  checksum: 10c0/531bcfb5616948d3468d95a1fd0adaeb0c20818ba4a500f439b800ca2117971489e02074ce32796fd64a6772ea3e7235fe0583d8241dbd37a053dc3378eff9a5
+  languageName: node
+  linkType: hard
+
+"serve-static@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "serve-static@npm:2.2.0"
+  dependencies:
+    encodeurl: "npm:^2.0.0"
+    escape-html: "npm:^1.0.3"
+    parseurl: "npm:^1.3.3"
+    send: "npm:^1.2.0"
+  checksum: 10c0/30e2ed1dbff1984836cfd0c65abf5d3f3f83bcd696c99d2d3c97edbd4e2a3ff4d3f87108a7d713640d290a7b6fe6c15ddcbc61165ab2eaad48ea8d3b52c7f913
+  languageName: node
+  linkType: hard
+
+"setprototypeof@npm:1.2.0":
+  version: 1.2.0
+  resolution: "setprototypeof@npm:1.2.0"
+  checksum: 10c0/68733173026766fa0d9ecaeb07f0483f4c2dc70ca376b3b7c40b7cda909f94b0918f6c5ad5ce27a9160bdfb475efaa9d5e705a11d8eaae18f9835d20976028bc
+  languageName: node
+  linkType: hard
+
 "shebang-command@npm:^2.0.0":
   version: 2.0.0
   resolution: "shebang-command@npm:2.0.0"
@@ -6871,6 +7415,54 @@ __metadata:
   bin:
     shx: lib/cli.js
   checksum: 10c0/83251fb09314682f5a192f0249a4be68c755933313a41b5152b11c19fc0a68311954d3ca971a0cbae05815786a893c59b82f356484d8eeb009c84f4066b3fa31
+  languageName: node
+  linkType: hard
+
+"side-channel-list@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "side-channel-list@npm:1.0.0"
+  dependencies:
+    es-errors: "npm:^1.3.0"
+    object-inspect: "npm:^1.13.3"
+  checksum: 10c0/644f4ac893456c9490ff388bf78aea9d333d5e5bfc64cfb84be8f04bf31ddc111a8d4b83b85d7e7e8a7b845bc185a9ad02c052d20e086983cf59f0be517d9b3d
+  languageName: node
+  linkType: hard
+
+"side-channel-map@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "side-channel-map@npm:1.0.1"
+  dependencies:
+    call-bound: "npm:^1.0.2"
+    es-errors: "npm:^1.3.0"
+    get-intrinsic: "npm:^1.2.5"
+    object-inspect: "npm:^1.13.3"
+  checksum: 10c0/010584e6444dd8a20b85bc926d934424bd809e1a3af941cace229f7fdcb751aada0fb7164f60c2e22292b7fa3c0ff0bce237081fd4cdbc80de1dc68e95430672
+  languageName: node
+  linkType: hard
+
+"side-channel-weakmap@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "side-channel-weakmap@npm:1.0.2"
+  dependencies:
+    call-bound: "npm:^1.0.2"
+    es-errors: "npm:^1.3.0"
+    get-intrinsic: "npm:^1.2.5"
+    object-inspect: "npm:^1.13.3"
+    side-channel-map: "npm:^1.0.1"
+  checksum: 10c0/71362709ac233e08807ccd980101c3e2d7efe849edc51455030327b059f6c4d292c237f94dc0685031dd11c07dd17a68afde235d6cf2102d949567f98ab58185
+  languageName: node
+  linkType: hard
+
+"side-channel@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "side-channel@npm:1.1.0"
+  dependencies:
+    es-errors: "npm:^1.3.0"
+    object-inspect: "npm:^1.13.3"
+    side-channel-list: "npm:^1.0.0"
+    side-channel-map: "npm:^1.0.1"
+    side-channel-weakmap: "npm:^1.0.2"
+  checksum: 10c0/cb20dad41eb032e6c24c0982e1e5a24963a28aa6122b4f05b3f3d6bf8ae7fd5474ef382c8f54a6a3ab86e0cac4d41a23bd64ede3970e5bfb50326ba02a7996e6
   languageName: node
   linkType: hard
 
@@ -7122,6 +7714,20 @@ __metadata:
   version: 0.0.2
   resolution: "stackback@npm:0.0.2"
   checksum: 10c0/89a1416668f950236dd5ac9f9a6b2588e1b9b62b1b6ad8dff1bfc5d1a15dbf0aafc9b52d2226d00c28dffff212da464eaeebfc6b7578b9d180cef3e3782c5983
+  languageName: node
+  linkType: hard
+
+"statuses@npm:2.0.1":
+  version: 2.0.1
+  resolution: "statuses@npm:2.0.1"
+  checksum: 10c0/34378b207a1620a24804ce8b5d230fea0c279f00b18a7209646d5d47e419d1cc23e7cbf33a25a1e51ac38973dc2ac2e1e9c647a8e481ef365f77668d72becfd0
+  languageName: node
+  linkType: hard
+
+"statuses@npm:^2.0.1":
+  version: 2.0.2
+  resolution: "statuses@npm:2.0.2"
+  checksum: 10c0/a9947d98ad60d01f6b26727570f3bcceb6c8fa789da64fe6889908fe2e294d57503b14bf2b5af7605c2d36647259e856635cd4c49eab41667658ec9d0080ec3f
   languageName: node
   linkType: hard
 
@@ -7494,6 +8100,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"toidentifier@npm:1.0.1":
+  version: 1.0.1
+  resolution: "toidentifier@npm:1.0.1"
+  checksum: 10c0/93937279934bd66cc3270016dd8d0afec14fb7c94a05c72dc57321f8bd1fa97e5bea6d1f7c89e728d077ca31ea125b78320a616a6c6cd0e6b9cb94cb864381c1
+  languageName: node
+  linkType: hard
+
 "traverse@npm:0.6.8":
   version: 0.6.8
   resolution: "traverse@npm:0.6.8"
@@ -7646,6 +8259,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"type-is@npm:^2.0.0, type-is@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "type-is@npm:2.0.1"
+  dependencies:
+    content-type: "npm:^1.0.5"
+    media-typer: "npm:^1.1.0"
+    mime-types: "npm:^3.0.0"
+  checksum: 10c0/7f7ec0a060b16880bdad36824ab37c26019454b67d73e8a465ed5a3587440fbe158bc765f0da68344498235c877e7dbbb1600beccc94628ed05599d667951b99
+  languageName: node
+  linkType: hard
+
 "typescript@npm:^5.5.4":
   version: 5.8.3
   resolution: "typescript@npm:5.8.3"
@@ -7751,6 +8375,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"unpipe@npm:1.0.0":
+  version: 1.0.0
+  resolution: "unpipe@npm:1.0.0"
+  checksum: 10c0/193400255bd48968e5c5383730344fbb4fa114cdedfab26e329e50dd2d81b134244bb8a72c6ac1b10ab0281a58b363d06405632c9d49ca9dfd5e90cbd7d0f32c
+  languageName: node
+  linkType: hard
+
+"uri-js@npm:^4.2.2":
+  version: 4.4.1
+  resolution: "uri-js@npm:4.4.1"
+  dependencies:
+    punycode: "npm:^2.1.0"
+  checksum: 10c0/4ef57b45aa820d7ac6496e9208559986c665e49447cb072744c13b66925a362d96dd5a46c4530a6b8e203e5db5fe849369444440cb22ecfc26c679359e5dfa3c
+  languageName: node
+  linkType: hard
+
 "url-join@npm:^5.0.0":
   version: 5.0.0
   resolution: "url-join@npm:5.0.0"
@@ -7802,6 +8442,13 @@ __metadata:
   version: 6.0.1
   resolution: "validate-npm-package-name@npm:6.0.1"
   checksum: 10c0/4d5455523e0a0c9a9ae3f306d4e6205c43be71dac85882db1c357ebbaf685390ea94985511824cfe41c04ca302dd85eb1f0292ab6941234b5ddca38d11865f9a
+  languageName: node
+  linkType: hard
+
+"vary@npm:^1, vary@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "vary@npm:1.1.2"
+  checksum: 10c0/f15d588d79f3675135ba783c91a4083dcd290a2a5be9fcb6514220a1634e23df116847b1cc51f66bfb0644cf9353b2abb7815ae499bab06e46dd33c1a6bf1f4f
   languageName: node
   linkType: hard
 
@@ -8120,7 +8767,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod@npm:^3.25.68":
+"zod-to-json-schema@npm:^3.24.1":
+  version: 3.24.6
+  resolution: "zod-to-json-schema@npm:3.24.6"
+  peerDependencies:
+    zod: ^3.24.1
+  checksum: 10c0/b907ab6d057100bd25a37e5545bf5f0efa5902cd84d3c3ec05c2e51541431a47bd9bf1e5e151a244273409b45f5986d55b26e5d207f98abc5200702f733eb368
+  languageName: node
+  linkType: hard
+
+"zod@npm:^3.23.8, zod@npm:^3.25.75":
   version: 3.25.76
   resolution: "zod@npm:3.25.76"
   checksum: 10c0/5718ec35e3c40b600316c5b4c5e4976f7fee68151bc8f8d90ec18a469be9571f072e1bbaace10f1e85cf8892ea12d90821b200e980ab46916a6166a4260a983c


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adds an initial implementation of an MCP server accessible via stdio. This exposes functions of toolkit-md via the MCP protocol so they can be consumed by tools like Cursor, Cline and Q Developer to help author and maintain Markdown content.

See README.md for more information


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
